### PR TITLE
Add Australian Xero tenant support

### DIFF
--- a/src/app/api/sync-logs/route.ts
+++ b/src/app/api/sync-logs/route.ts
@@ -1,6 +1,6 @@
 import { getSyncLogsCsv } from '@sync-logs/api/syncLogs.controller'
 import { withErrorHandler } from '@/utils/withErrorHandler'
 
-export const maxDuration = 800
+export const maxDuration = 300
 
 export const GET = withErrorHandler(getSyncLogsCsv)

--- a/src/features/invoice-sync/lib/SyncedTaxRates.service.ts
+++ b/src/features/invoice-sync/lib/SyncedTaxRates.service.ts
@@ -6,6 +6,28 @@ import AuthenticatedXeroService from '@/lib/xero/AuthenticatedXero.service'
 import { type TaxRateCreatePayload, TaxRateCreatePayloadSchema } from '@/lib/xero/types'
 import { areNumbersEqual } from '@/utils/number'
 
+/**
+ * Set of ReportTaxType values that represent OUTPUT (sales) tax types.
+ * These are valid for applying to sales invoices across all Xero regions:
+ * - OUTPUT: Standard sales tax (US) / GST on Income (AU)
+ * - OUTPUT2: Secondary output tax (used in some regions)
+ * - SALESOUTPUT: Explicit sales output designation
+ * - CAPITALSALESOUTPUT: Capital sales output
+ *
+ * INPUT-prefixed types are for purchase taxes and must NOT be applied to invoices.
+ */
+const OUTPUT_TAX_TYPES = new Set<TaxRate.ReportTaxTypeEnum>([
+  TaxRate.ReportTaxTypeEnum.OUTPUT,
+  TaxRate.ReportTaxTypeEnum.OUTPUT2,
+  TaxRate.ReportTaxTypeEnum.SALESOUTPUT,
+  TaxRate.ReportTaxTypeEnum.CAPITALSALESOUTPUT,
+  TaxRate.ReportTaxTypeEnum.USSALESTAX,
+])
+
+const isOutputTaxRate = (taxRate: TaxRate): boolean => {
+  return taxRate.reportTaxType != null && OUTPUT_TAX_TYPES.has(taxRate.reportTaxType)
+}
+
 class SyncedTaxRatesService extends AuthenticatedXeroService {
   async getTaxRateForItem(effectiveRate: number) {
     logger.info(
@@ -14,23 +36,25 @@ class SyncedTaxRatesService extends AuthenticatedXeroService {
     )
 
     const taxRates = await this.xero.getTaxRates(this.connection.tenantId)
-    let matchingTaxRate = taxRates?.find((t) => areNumbersEqual(t.effectiveRate, effectiveRate))
+    let matchingTaxRate = taxRates?.find(
+      (t) => areNumbersEqual(t.effectiveRate, effectiveRate) && isOutputTaxRate(t),
+    )
 
     if (!matchingTaxRate) {
       logger.info(
         'SyncedTaxRatesService#getTaxRateForItem :: Tax Rate not found... creating a new one',
       )
       const payload = {
-        name: `Assembly Sales Tax - ${effectiveRate}%`,
+        name: `Assembly Tax - ${effectiveRate}%`,
         taxComponents: [
           {
-            name: `Assembly Sales Tax ${effectiveRate}%`,
+            name: `Assembly Tax ${effectiveRate}%`,
             rate: effectiveRate,
             isCompound: false,
             isNonRecoverable: false,
           } satisfies TaxComponent,
         ],
-        // reportTaxType: TaxRate.ReportTaxTypeEnum.OUTPUT,
+        reportTaxType: TaxRate.ReportTaxTypeEnum.OUTPUT,
         status: TaxRate.StatusEnum.ACTIVE,
       } satisfies TaxRateCreatePayload
 

--- a/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
+++ b/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
@@ -93,10 +93,11 @@ export const ProductMappingTableRow = ({
     setOpenDropdownId(null)
   }
 
-  const renderUSD = (amount: number) =>
-    new Intl.NumberFormat('en-US', {
+  const currencyCode = item.price.currency || 'USD'
+  const formatCurrency = (amount: number) =>
+    new Intl.NumberFormat(undefined, {
       style: 'currency',
-      currency: 'USD',
+      currency: currencyCode,
     }).format(amount || 0)
 
   return (
@@ -107,7 +108,7 @@ export const ProductMappingTableRow = ({
           {item.product.name}
         </div>
         <div className="text-body-xs text-text-secondary leading-5">
-          {renderUSD(item.price.amount / 100)}
+          {formatCurrency(item.price.amount / 100)}
         </div>
       </td>
 
@@ -136,7 +137,7 @@ export const ProductMappingTableRow = ({
                   {xeroItem.name}
                 </div>
                 <div className="text-body-xs text-text-secondary leading-5">
-                  {renderUSD(xeroItem.amount)}
+                  {formatCurrency(xeroItem.amount)}
                 </div>
               </div>
             ) : (
@@ -195,7 +196,7 @@ export const ProductMappingTableRow = ({
                         {item.name}
                       </span>
                       <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
-                        {renderUSD(item.amount)}
+                        {formatCurrency(item.amount)}
                       </span>
                     </button>
                   ))


### PR DESCRIPTION
## Summary
- **Fix tax rate matching for AU tenants**: Filter tax rates by OUTPUT `reportTaxType` so Australian tenants select "GST on Income" (OUTPUT, 10%) instead of accidentally matching "GST on Purchases" (INPUT, 10%). Previously, matching was by `effectiveRate` alone, which is ambiguous when AU tenants have both INPUT and OUTPUT rates at the same percentage.
- **Fix hardcoded USD currency display**: Product mapping table now reads `item.price.currency` dynamically (with USD fallback) instead of hardcoding `en-US` / `USD`. Australian products will display `A$` correctly.
- **Fix Vercel deployment**: Reduce `sync-logs` route `maxDuration` from 800 → 300 to comply with Vercel Pro plan limits.

## Changes
### `SyncedTaxRates.service.ts` (core fix)
- Added `OUTPUT_TAX_TYPES` set covering all valid sales tax report types (`OUTPUT`, `OUTPUT2`, `SALESOUTPUT`, `CAPITALSALESOUTPUT`, `USSALESTAX`)
- Tax rate lookup now filters by both `effectiveRate` AND `isOutputTaxRate()`
- Uncommented `reportTaxType: OUTPUT` on tax rate creation payload so newly created rates are properly tagged
- Renamed labels from "Assembly Sales Tax" → "Assembly Tax" (region-neutral)

### `ProductMappingTableRow.tsx` (currency fix)
- Replaced `renderUSD()` with `formatCurrency()` that reads `item.price.currency || 'USD'`
- Uses `Intl.NumberFormat(undefined, ...)` so locale is auto-detected from browser

### `sync-logs/route.ts` (deployment fix)
- `maxDuration` 800 → 300

## How to test
1. Connect to an **Australian Xero Demo Company** (or any AU tenant)
2. **Tax rates**: Trigger an invoice sync with a taxed line item. Verify:
   - The matched tax rate has `reportTaxType: OUTPUT` (e.g., "GST on Income"), NOT `INPUT`
   - If no OUTPUT match exists, a new "Assembly Tax - 10%" rate is created with `reportTaxType: OUTPUT`
3. **Currency**: Go to Settings → Product Mapping. Verify AU products show `A$` (AUD) formatting, not `$` (USD)
4. **Regression**: Repeat with a US tenant to confirm existing behavior is unchanged (US tax rates are all OUTPUT-type, so the filter is transparent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)