### PR TITLE
OUT-3595: preserve underlying error in xero callback handler

### DIFF
--- a/src/features/auth/lib/Auth.service.ts
+++ b/src/features/auth/lib/Auth.service.ts
@@ -33,10 +33,10 @@ class AuthService extends BaseService {
       tenantId = await xero.getActiveTenantId()
     } catch (error) {
       logger.error(
-        'XeroConnectionsService#handleXeroConnectionCallback :: Error handling Xero callback:',
+        'AuthService#handleXeroConnectionCallback :: Error handling Xero callback:',
         error,
       )
-      throw new Error('Error handling Xero callback')
+      throw new Error('Error handling Xero callback', { cause: error })
     }
 
     const xeroConnectionsService = new XeroConnectionsService(this.user)


### PR DESCRIPTION
## Summary

- [x] The generic wrapper was masking the real Xero SDK error in Sentry, making the 400 token-exchange failure undiagnosable. 
- [x] Pass the original error via cause so it surfaces on the next occurrence.
