### PR TITLE
OUT-3689: de-duplicate Xero auth failure notifications

### DIFF
--- a/src/features/auth/lib/Auth.service.ts
+++ b/src/features/auth/lib/Auth.service.ts
@@ -47,7 +47,15 @@ class AuthService extends BaseService {
     })
   }
 
-  private async handleRefreshFailure(safe: boolean, connection?: XeroConnection) {
+  private async handleRefreshFailure({
+    safe,
+    notify,
+    connection,
+  }: {
+    safe: boolean
+    notify: boolean
+    connection?: XeroConnection
+  }) {
     logger.info(
       'AuthService#handleRefreshFailure :: Handling refresh failure for safe mode',
       safe,
@@ -56,7 +64,7 @@ class AuthService extends BaseService {
     )
 
     if (!safe) {
-      await sendAuthorizationFailedNotification(this.user, connection)
+      if (notify) await sendAuthorizationFailedNotification(this.user, connection)
       throw new XeroConnectionFailedError()
     }
   }
@@ -64,7 +72,7 @@ class AuthService extends BaseService {
   /**
    * Authorize Xero for a Copilot workspace using a token payload
    * Ref: https://developer.xero.com/documentation/guides/oauth2/auth-flow/
-   * @param opts - `safe` flag is for safe handling of errors. `true` does not trigger an error, `false` does.
+   * @param safe - When `true`, swallow auth errors instead of throwing/notifying.
    */
   // Overloads
   authorizeXeroForCopilotWorkspace(): Promise<XeroConnectionWithTokenSet>
@@ -95,15 +103,17 @@ class AuthService extends BaseService {
     // --- Handle active connection
     if (!isAccessTokenValid) {
       // --- Handle inactive connection
-      // Update connection as inactive first
-      connection = await this.connectionsService.updateConnectionForWorkspace({ status: false })
+      // Only the first failure flips active->inactive, so we notify once even when
+      // many webhooks fail at the same time. (Re-flipped to active on refresh below.)
+      const didDeactivate = await this.connectionsService.deactivateConnectionIfActive()
+      connection = { ...connection, status: false }
 
       // If Xero connection was not found or unrefreshable. Send a mail prompting IUs to re-authorize
       if (!connection.tokenSet || !connection.tokenSet.refresh_token) {
         logger.info(
           'AuthService#authorizeXeroForCopilotWorkspace :: Unable to refresh Xero access token, no refresh token available',
         )
-        await this.handleRefreshFailure(safe, connection)
+        await this.handleRefreshFailure({ safe, notify: didDeactivate, connection })
       } else {
         logger.info('AuthService#authorizeXeroForCopilotWorkspace :: Refreshing Xero access token')
         // Attempt to refresh access token via refresh token
@@ -118,7 +128,7 @@ class AuthService extends BaseService {
         } catch (e: unknown) {
           // If unable to refresh, send notification email
           logger.error('Error refreshing Xero access token:', e)
-          await this.handleRefreshFailure(safe, connection)
+          await this.handleRefreshFailure({ safe, notify: didDeactivate, connection })
         }
       }
     }

--- a/src/features/auth/lib/Auth.service.ts
+++ b/src/features/auth/lib/Auth.service.ts
@@ -57,22 +57,24 @@ class AuthService extends BaseService {
     connection?: XeroConnection
   }) {
     logger.info(
-      'AuthService#handleRefreshFailure :: Handling refresh failure for safe mode',
+      'AuthService#handleRefreshFailure :: Handling refresh failure with safe',
       safe,
+      'notify',
+      notify,
       'and connection',
       connection?.id,
     )
 
-    if (!safe) {
-      if (notify) await sendAuthorizationFailedNotification(this.user, connection)
-      throw new XeroConnectionFailedError()
-    }
+    // Notify once per failure (whoever wins the active->inactive flip), even in safe
+    // mode — `safe` only decides whether to throw.
+    if (notify) await sendAuthorizationFailedNotification(this.user, connection)
+    if (!safe) throw new XeroConnectionFailedError()
   }
 
   /**
    * Authorize Xero for a Copilot workspace using a token payload
    * Ref: https://developer.xero.com/documentation/guides/oauth2/auth-flow/
-   * @param safe - When `true`, swallow auth errors instead of throwing/notifying.
+   * @param safe - When `true`, return the inactive connection instead of throwing.
    */
   // Overloads
   authorizeXeroForCopilotWorkspace(): Promise<XeroConnectionWithTokenSet>
@@ -104,7 +106,7 @@ class AuthService extends BaseService {
     if (!isAccessTokenValid) {
       // --- Handle inactive connection
       // Only the first failure flips active->inactive, so we notify once even when
-      // many webhooks fail at the same time. (Re-flipped to active on refresh below.)
+      // many events fail at the same time. (Re-flipped to active on refresh below.)
       const didDeactivate = await this.connectionsService.deactivateConnectionIfActive()
       connection = { ...connection, status: false }
 

--- a/src/features/auth/lib/XeroConnections.service.ts
+++ b/src/features/auth/lib/XeroConnections.service.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import type { TokenSet } from 'xero-node'
 import { z } from 'zod'
 import {
@@ -56,6 +56,21 @@ class XeroConnectionsService extends BaseService {
       .where(eq(xeroConnections.portalId, this.user.portalId))
       .returning()
     return connections[0]
+  }
+
+  /**
+   * Mark the connection inactive only if it's currently active.
+   * Returns true if this call did the flip — lets callers notify just once.
+   */
+  async deactivateConnectionIfActive(): Promise<boolean> {
+    const rows = await this.db
+      .update(xeroConnections)
+      .set({ status: false })
+      .where(
+        and(eq(xeroConnections.portalId, this.user.portalId), eq(xeroConnections.status, true)),
+      )
+      .returning()
+    return rows.length > 0
   }
 
   async handleXeroConnectionCallback(

--- a/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
+++ b/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
@@ -33,10 +33,16 @@ class RetryFailedSyncsService {
         const user = await User.authenticate(token)
 
         const authService = new AuthService(user)
-        const connection = await authService.authorizeXeroForCopilotWorkspace()
+        // Safe mode: retries shouldn't notify. Skip below if the connection is dead.
+        const connection = await authService.authorizeXeroForCopilotWorkspace(true)
+        const { tokenSet, tenantId } = connection
+        if (!connection.status || !tokenSet || !tenantId) {
+          logger.info('Skipping failed sync; Xero connection is inactive', failedSync.id)
+          continue
+        }
         logger.info('Found connection', connection.id)
 
-        const webhookService = new WebhookService(user, connection)
+        const webhookService = new WebhookService(user, { ...connection, tokenSet, tenantId })
         await webhookService.handleEvent({
           eventType: failedSync.type,
           // biome-ignore lint/suspicious/noExplicitAny: payload can literally be anything

--- a/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
+++ b/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
@@ -33,16 +33,10 @@ class RetryFailedSyncsService {
         const user = await User.authenticate(token)
 
         const authService = new AuthService(user)
-        // Safe mode: retries shouldn't notify. Skip below if the connection is dead.
-        const connection = await authService.authorizeXeroForCopilotWorkspace(true)
-        const { tokenSet, tenantId } = connection
-        if (!connection.status || !tokenSet || !tenantId) {
-          logger.info('Skipping failed sync; Xero connection is inactive', failedSync.id)
-          continue
-        }
+        const connection = await authService.authorizeXeroForCopilotWorkspace()
         logger.info('Found connection', connection.id)
 
-        const webhookService = new WebhookService(user, { ...connection, tokenSet, tenantId })
+        const webhookService = new WebhookService(user, connection)
         await webhookService.handleEvent({
           eventType: failedSync.type,
           // biome-ignore lint/suspicious/noExplicitAny: payload can literally be anything


### PR DESCRIPTION
## Summary

Fixes duplicate "Xero Integration Has Stopped Working" notifications ([OUT-3689](https://linear.app/assemblycom/issue/OUT-3689/investigate-duplicate-xero-integration-notifications)).

Root cause: the notification fired once **per trigger** with no de-duplication. When multiple webhook events hit an expired/dead Xero connection at the same time (and on webhook redelivery), each one independently sent the "stopped working" notification — so IUs saw the same message repeated.

## Changes

- **Notify only on the `active -> inactive` transition.** A new race-safe conditional update (`UPDATE ... WHERE status = true RETURNING`) in `deactivateConnectionIfActive()` means only the first failing call flips the connection and notifies; concurrent callers and redeliveries get `didDeactivate = false` and stay silent until the connection is reconnected (which re-arms it).
- **Decouple the notification from the `safe` flag.** `safe` now controls only whether `authorize()` throws; the notification is gated purely on the transition. So whichever path first detects the broken connection — a webhook, a settings action, or an app load via `page.tsx` — notifies all IUs exactly once. (Previously a `safe` caller could silently consume the transition and suppress the alert.)

## Notes

- Intentional fan-out to all internal users is preserved — the dedup is per-failure, not per-user.
- The retry-failed-syncs cron is unchanged; the transition gate already de-duplicates its notifications.
- Out of scope (pre-existing): dead-connection `failed_syncs` rows still don't age out (`attempts` never increments in this path). Worth a separate ticket.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- No test framework configured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)