### PR TITLE
OUT-3840: bill company invoices to earliest active client when company name is off

### DIFF
--- a/src/features/invoice-sync/lib/SyncedContacts.service.ts
+++ b/src/features/invoice-sync/lib/SyncedContacts.service.ts
@@ -38,10 +38,7 @@ class SyncedContactsService extends AuthenticatedXeroService {
       const clients = await this.copilot.getCompanyClients(companyId)
       client = getEarliestActiveClient(clients)
 
-      if (!client)
-        throw new APIError('No active client found for company', status.BAD_REQUEST, {
-          error: 'No active client found for company',
-        })
+      if (!client) throw new APIError('No active client found for company', status.BAD_REQUEST)
       billedClientId = client.id
     } else if (!clientId) {
       // Billed to company with useCompanyName on: use the company name (unless it's a placeholder).

--- a/src/features/invoice-sync/lib/SyncedContacts.service.ts
+++ b/src/features/invoice-sync/lib/SyncedContacts.service.ts
@@ -33,6 +33,8 @@ class SyncedContactsService extends AuthenticatedXeroService {
     let company: CompanyResponse | undefined
     let useNonPlaceholderCompanyName = false
 
+    // Case where an invoice is billed to a company.
+    // If an invoice is billed to a client, this whole if else block is skipped.
     if (!useCompanyName && !clientId) {
       // Billed to company but useCompanyName is off: bill the earliest active client of the company.
       const clients = await this.copilot.getCompanyClients(companyId)

--- a/src/features/invoice-sync/lib/SyncedContacts.service.ts
+++ b/src/features/invoice-sync/lib/SyncedContacts.service.ts
@@ -14,7 +14,7 @@ import { SyncedContactUserType, syncedContacts } from '@/db/schema/syncedContact
 import { SyncEntityType, SyncEventType, SyncStatus } from '@/db/schema/syncLogs.schema'
 import APIError from '@/errors/APIError'
 import type { ClientResponse, CompanyResponse } from '@/lib/copilot/types'
-import { buildClientName } from '@/lib/copilot/utils'
+import { buildClientName, getEarliestActiveClient } from '@/lib/copilot/utils'
 import logger from '@/lib/logger'
 import AuthenticatedXeroService from '@/lib/xero/AuthenticatedXero.service'
 import type { ContactCreatePayload, ValidContact } from '@/lib/xero/types'
@@ -27,22 +27,34 @@ class SyncedContactsService extends AuthenticatedXeroService {
     const settingsService = new SettingsService(this.user, this.connection)
     const { useCompanyName } = await settingsService.getOrCreateSettings()
 
-    const client = clientId ? await this.copilot.getClient(clientId) : undefined
+    let client = clientId ? await this.copilot.getClient(clientId) : undefined
+    let billedClientId = clientId
 
     let company: CompanyResponse | undefined
-    // If useCompanyName is true or clientId is undefined, then the invoice is billed to a company
-    // `company` variable will be populated then.
-    if (useCompanyName || !clientId) {
+    let useNonPlaceholderCompanyName = false
+
+    if (!useCompanyName && !clientId) {
+      // Billed to company but useCompanyName is off: bill the earliest active client of the company.
+      const clients = await this.copilot.getCompanyClients(companyId)
+      client = getEarliestActiveClient(clients)
+
+      if (!client)
+        throw new APIError('No active client found for company', status.BAD_REQUEST, {
+          error: 'No active client found for company',
+        })
+      billedClientId = client.id
+    } else if (!clientId) {
+      // Billed to company with useCompanyName on: use the company name (unless it's a placeholder).
       company = await this.copilot.getCompany(companyId)
+
+      if (company?.isPlaceholder)
+        throw new APIError(
+          'Cannot use company name of place holder company for invoice',
+          status.BAD_REQUEST,
+        )
+      useNonPlaceholderCompanyName = true
     }
-
-    const useNonPlaceholderCompanyName = useCompanyName && !company?.isPlaceholder
-
-    if (!useNonPlaceholderCompanyName && !clientId)
-      throw new APIError(
-        'Cannot use company name of place holder company for invoice',
-        status.BAD_REQUEST,
-      )
+    // Otherwise (clientId present), the invoice is billed directly to that client.
 
     const query = this.db
       .select({ contactID: syncedContacts.contactId })
@@ -53,11 +65,11 @@ class SyncedContactsService extends AuthenticatedXeroService {
           eq(syncedContacts.tenantId, this.connection.tenantId),
           eq(
             syncedContacts.clientOrCompanyId,
-            useNonPlaceholderCompanyName || !clientId ? companyId : clientId,
+            useNonPlaceholderCompanyName || !billedClientId ? companyId : billedClientId,
           ),
           eq(
             syncedContacts.userType,
-            useNonPlaceholderCompanyName || !clientId
+            useNonPlaceholderCompanyName || !billedClientId
               ? SyncedContactUserType.COMPANY
               : SyncedContactUserType.CLIENT,
           ),
@@ -82,14 +94,14 @@ class SyncedContactsService extends AuthenticatedXeroService {
             eq(syncedContacts.tenantId, this.connection.tenantId),
             eq(
               syncedContacts.clientOrCompanyId,
-              useNonPlaceholderCompanyName || !clientId ? companyId : clientId,
+              useNonPlaceholderCompanyName || !billedClientId ? companyId : billedClientId,
             ),
           ),
         )
     }
 
     logger.info(
-      `SyncedContactsService#createContact :: Couldn't find existing client... creating a new one for ${clientId}`,
+      `SyncedContactsService#createContact :: Couldn't find existing client... creating a new one for ${billedClientId}`,
     )
     contact = await this.createContact(client, company)
 

--- a/src/lib/copilot/utils.ts
+++ b/src/lib/copilot/utils.ts
@@ -1,2 +1,17 @@
+import type { ClientResponse } from './types'
+
 export const buildClientName = (client: { givenName: string; familyName: string }) =>
   `${client.givenName} ${client.familyName}`
+
+const ACTIVE_CLIENT_STATUS = 'active'
+
+// Returns the earliest-created active client, or undefined if none are active.
+// createdAt is an ISO string, so lexical comparison orders chronologically.
+export const getEarliestActiveClient = (clients: ClientResponse[]): ClientResponse | undefined =>
+  clients
+    .filter((client) => client.status === ACTIVE_CLIENT_STATUS)
+    .reduce<ClientResponse | undefined>(
+      (earliest, client) =>
+        !earliest || client.createdAt < earliest.createdAt ? client : earliest,
+      undefined,
+    )

--- a/src/lib/copilot/utils.ts
+++ b/src/lib/copilot/utils.ts
@@ -7,10 +7,11 @@ const ACTIVE_CLIENT_STATUS = 'active'
 
 // Returns the earliest-created active client, or undefined if none are active.
 export const getEarliestActiveClient = (clients: ClientResponse[]): ClientResponse | undefined =>
-  clients
-    .filter((client) => client.status === ACTIVE_CLIENT_STATUS)
-    .reduce<ClientResponse | undefined>(
-      (earliest, client) =>
-        !earliest || new Date(client.createdAt) < new Date(earliest.createdAt) ? client : earliest,
-      undefined,
-    )
+  clients.reduce<ClientResponse | undefined>(
+    (earliest, client) =>
+      client.status === ACTIVE_CLIENT_STATUS &&
+      (!earliest || new Date(client.createdAt) < new Date(earliest.createdAt))
+        ? client
+        : earliest,
+    undefined,
+  )

--- a/src/lib/copilot/utils.ts
+++ b/src/lib/copilot/utils.ts
@@ -6,12 +6,11 @@ export const buildClientName = (client: { givenName: string; familyName: string 
 const ACTIVE_CLIENT_STATUS = 'active'
 
 // Returns the earliest-created active client, or undefined if none are active.
-// createdAt is an ISO string, so lexical comparison orders chronologically.
 export const getEarliestActiveClient = (clients: ClientResponse[]): ClientResponse | undefined =>
   clients
     .filter((client) => client.status === ACTIVE_CLIENT_STATUS)
     .reduce<ClientResponse | undefined>(
       (earliest, client) =>
-        !earliest || client.createdAt < earliest.createdAt ? client : earliest,
+        !earliest || new Date(client.createdAt) < new Date(earliest.createdAt) ? client : earliest,
       undefined,
     )


### PR DESCRIPTION
## Summary

Fixes [OUT-3840](https://linear.app/assemblycom/issue/OUT-3840). When **Use company name** is **off** and an invoice is billed to a company (no `clientId`), the contact sync previously threw `Cannot use company name of placeholder company for invoice` for *every* such invoice — even non-placeholder companies. It now falls back to billing the **earliest active client** of the company.

## Changes

- Add `getEarliestActiveClient` (`src/lib/copilot/utils.ts`) — filters clients to `status === 'active'` and picks the earliest by `createdAt`.
- Rework the billing-target resolution in `SyncedContactsService#getSyncedContact`:
  - off + company → earliest active client (throws `No active client found for company` if none)
  - on + company → company name (still rejects placeholder companies)
  - client present (either flag) → bill that client directly
- Clarity cleanup: simplify the branch conditions, fix misleading comments, rename `tempClientId` → `billedClientId`.

## Billing matrix

| Use company name | Billed to | Result |
|---|---|---|
| on | company | company contact |
| on | client | client contact |
| off | company | earliest active client |
| off | client | client contact |

## Notes

- Client `status` values are `notInvited` / `invited` / `active`; only `active` is selected.
- Behavior change vs `main`: flag-on invoices billed to an individual client now sync as the **client** contact (previously the company). Existing customers synced as company contacts under the old logic may get a new client contact created in Xero — no backfill.

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)