### PR TITLE
OUT-3844: move realtime connection status to dedicated table

### DIFF
--- a/docs/rls-and-realtime-connection-status.md
+++ b/docs/rls-and-realtime-connection-status.md
@@ -1,0 +1,126 @@
+# RLS, Grants & Realtime for `xero_connection_status`
+
+This document describes the database security setup that lets the UI subscribe to
+Xero connection status changes over Supabase Realtime **without** exposing any
+sensitive data to the public `anon` role.
+
+**Snippet location:**
+`supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql`
+([open](../supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql))
+
+It is run **manually** against the database (it is not a Drizzle migration).
+
+## Background
+
+The app needs the browser to know, in real time, when a portal's Xero
+connection changes. Supabase Realtime delivers row changes to the client using
+the `anon` key, which means any table it broadcasts is readable by the public
+`anon` role under RLS.
+
+Broadcasting `xero_connections` directly is unsafe — that table holds
+`tokenSet` (OAuth access/refresh tokens). To avoid leaking secrets, a dedicated
+mirror table `xero_connection_status` holds only non-sensitive fields:
+
+| Column       | Type          | Notes                          |
+| ------------ | ------------- | ------------------------------ |
+| `portal_id`  | `varchar(64)` | Primary key                    |
+| `status`     | `boolean`     | Connection status              |
+| `updated_at` | `timestamptz` | Last status change             |
+
+An `AFTER INSERT OR UPDATE` trigger on `xero_connections` upserts into this
+mirror table, guarded by `IS DISTINCT FROM` so token-only writes don't generate
+realtime noise. Realtime then subscribes to `xero_connection_status` only.
+
+## What the snippet does
+
+The snippet runs as a single transaction and performs four things:
+
+### 1. Revoke all `anon` access from every table, then grant select on the mirror
+
+```sql
+REVOKE INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA public FROM anon;
+GRANT SELECT ON xero_connection_status TO anon;
+```
+
+`anon` loses all read/write privileges on every table in `public`, then is
+granted **`SELECT` only** on `xero_connection_status`. This is the *grant* layer
+— it controls which tables `anon` can touch at all. The mirror table is the only
+one `anon` can read, which is exactly what Realtime needs.
+
+### 2. Create the RLS policy before enabling RLS
+
+```sql
+CREATE POLICY "anon can read connection status"
+  ON xero_connection_status FOR SELECT
+  TO anon USING (true);
+```
+
+This is the *RLS* layer. With RLS enabled and no policy, every row is denied by
+default. The policy is created **before** RLS is enabled to avoid a window where
+`anon` reads are blocked (a default-deny gap). `USING (true)` allows `anon` to
+read all rows of the mirror table — safe because the table contains no secrets.
+
+> Grants and RLS are two independent gates. A query must pass **both**: the role
+> needs the table-level `GRANT`, *and* the row must satisfy an RLS policy.
+
+### 3. Enable RLS on all public tables
+
+```sql
+do $$
+declare
+  r record;
+begin
+  for r in
+    select tablename
+    from pg_tables
+    where schemaname = 'public'
+  loop
+    execute format('alter table public.%I enable row level security;', r.tablename);
+  end loop;
+end $$;
+```
+
+RLS is enabled on **every** table in `public`. Tables other than
+`xero_connection_status` have no `anon` policy and no `anon` grant, so they are
+fully locked down for the public role. The application's own database role (the
+service/connection role used by Drizzle) is unaffected and continues to operate
+normally.
+
+### 4. Repoint Realtime at the mirror table
+
+```sql
+ALTER PUBLICATION supabase_realtime ADD TABLE xero_connection_status;
+ALTER PUBLICATION supabase_realtime DROP TABLE xero_connections;
+```
+
+Realtime broadcasts come from the `supabase_realtime` publication. The mirror
+table is added and `xero_connections` is removed, so token data is never part of
+a realtime payload.
+
+## Security summary
+
+- **Every** `public` table has RLS enabled.
+- `anon` has **no** access to any table except `SELECT` on
+  `xero_connection_status`.
+- `xero_connection_status` exposes only `portal_id`, `status`, `updated_at` —
+  no secrets.
+- `xero_connections` (with `tokenSet`) is no longer broadcast over Realtime.
+
+## How the client uses it
+
+`useRealtimeXeroConnections`
+([`src/features/auth/hooks/useRealtimeXeroConnections.ts`](../src/features/auth/hooks/useRealtimeXeroConnections.ts))
+subscribes to `UPDATE` events on `xero_connection_status`, filtered to the
+current portal (`portal_id=eq.${portalId}`). When the status changes it reloads
+the page so the UI reflects the new connection state.
+
+## Running the snippet
+
+The snippet lives at
+`supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql`.
+
+It is **not** a Drizzle migration — run it manually (e.g. via the Supabase SQL
+editor or `psql`) after the
+`20260610095713_add_xero_connection_status` migration has created the table,
+trigger, and backfill. The whole snippet is wrapped in `BEGIN; … COMMIT;`, so it
+applies atomically.

--- a/src/db/migrations/20260610095713_add_xero_connection_status.sql
+++ b/src/db/migrations/20260610095713_add_xero_connection_status.sql
@@ -1,0 +1,26 @@
+CREATE TABLE "xero_connection_status" (
+	"portal_id" varchar(64) PRIMARY KEY NOT NULL,
+	"status" boolean DEFAULT false NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE OR REPLACE FUNCTION sync_xero_connection_status()
+RETURNS trigger AS $$
+BEGIN
+  IF TG_OP = 'INSERT' OR OLD.status IS DISTINCT FROM NEW.status THEN
+    INSERT INTO xero_connection_status (portal_id, status, updated_at)
+    VALUES (NEW.portal_id, NEW.status, now())
+    ON CONFLICT (portal_id) DO UPDATE
+      SET status = EXCLUDED.status, updated_at = now();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+--> statement-breakpoint
+CREATE TRIGGER trg_sync_xero_connection_status
+  AFTER INSERT OR UPDATE ON xero_connections
+  FOR EACH ROW EXECUTE FUNCTION sync_xero_connection_status();
+--> statement-breakpoint
+INSERT INTO xero_connection_status (portal_id, status, updated_at)
+SELECT portal_id, status, now() FROM xero_connections
+ON CONFLICT (portal_id) DO NOTHING;

--- a/src/db/migrations/meta/20260610095713_snapshot.json
+++ b/src/db/migrations/meta/20260610095713_snapshot.json
@@ -1,0 +1,947 @@
+{
+  "id": "735599a1-fa37-449d-aaa6-5da689e95231",
+  "prevId": "bbe2b235-bb56-4cd0-a89a-cd542dcb3656",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.failed_syncs": {
+      "name": "failed_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "failed_syncs_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_failed_syncs_resource_id": {
+          "name": "uq_failed_syncs_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_products_automatically": {
+          "name": "sync_products_automatically",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "add_absorbed_fees": {
+          "name": "add_absorbed_fees",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_company_name": {
+          "name": "use_company_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sync_enabled": {
+          "name": "is_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_invoice_settings_mapping": {
+          "name": "initial_invoice_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_product_settings_mapping": {
+          "name": "initial_product_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_settings_portal_id_tenant_id": {
+          "name": "uq_settings_portal_id_tenant_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_date": {
+          "name": "sync_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "sync_logs_event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_logs_status",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "sync_logs_entity_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_id": {
+          "name": "copilot_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_id": {
+          "name": "xero_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_price": {
+          "name": "product_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_item_name": {
+          "name": "xero_item_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_portal_id_tenant_id_created_at": {
+          "name": "idx_sync_logs_portal_id_tenant_id_created_at",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_contacts": {
+      "name": "synced_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_or_company_id": {
+          "name": "client_or_company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "synced_contacts_contact_user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLIENT'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_contacts_portal_id_tenant_id_client_or_company_id": {
+          "name": "uq_synced_contacts_portal_id_tenant_id_client_or_company_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_or_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_invoices": {
+      "name": "synced_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "synced_invoices_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_invoices_portal_id_copilot_invoice_id": {
+          "name": "uq_synced_invoices_portal_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_items": {
+      "name": "synced_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price_id": {
+          "name": "price_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_items_portal_id_product_id_price_id": {
+          "name": "uq_synced_items_portal_id_product_id_price_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "price_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_payments": {
+      "name": "synced_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_payment_id": {
+          "name": "copilot_payment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_payment_id": {
+          "name": "xero_payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "synced_payments_payment_type",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'payment'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id": {
+          "name": "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_synced_payments_xero_payment_id": {
+          "name": "uq_synced_payments_xero_payment_id",
+          "columns": [
+            {
+              "expression": "xero_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connection_status": {
+      "name": "xero_connection_status",
+      "schema": "",
+      "columns": {
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connections": {
+      "name": "xero_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_set": {
+          "name": "token_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_xero_connections_portal_id": {
+          "name": "uq_xero_connections_portal_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.failed_syncs_type": {
+      "name": "failed_syncs_type",
+      "schema": "public",
+      "values": [
+        "invoice.created",
+        "invoice.updated",
+        "invoice.paid",
+        "invoice.voided",
+        "invoice.deleted",
+        "product.updated",
+        "price.created",
+        "payment.succeeded"
+      ]
+    },
+    "public.sync_logs_entity_type": {
+      "name": "sync_logs_entity_type",
+      "schema": "public",
+      "values": ["invoice", "customer", "product", "expense"]
+    },
+    "public.sync_logs_event_type": {
+      "name": "sync_logs_event_type",
+      "schema": "public",
+      "values": ["created", "mapped", "unmapped", "paid", "voided", "updated", "deleted"]
+    },
+    "public.sync_logs_status": {
+      "name": "sync_logs_status",
+      "schema": "public",
+      "values": ["success", "failed", "info"]
+    },
+    "public.synced_invoices_status": {
+      "name": "synced_invoices_status",
+      "schema": "public",
+      "values": ["pending", "failed", "success"]
+    },
+    "public.synced_payments_payment_type": {
+      "name": "synced_payments_payment_type",
+      "schema": "public",
+      "values": ["payment", "expense"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -78,6 +78,13 @@
       "when": 1780580743823,
       "tag": "20260604134543_add_country_code_to_settings",
       "breakpoints": false
+    },
+    {
+      "idx": 11,
+      "version": "7",
+      "when": 1781085433576,
+      "tag": "20260610095713_add_xero_connection_status",
+      "breakpoints": false
     }
   ]
 }

--- a/src/db/schema/index.ts
+++ b/src/db/schema/index.ts
@@ -2,10 +2,12 @@ import { settings } from './settings.schema'
 import { syncedContacts } from './syncedContacts.schema'
 import { syncedInvoices } from './syncedInvoices.schema'
 import { syncedItems } from './syncedItems.schema'
+import { xeroConnectionStatus } from './xeroConnectionStatus.schema'
 import { xeroConnections } from './xeroConnections.schema'
 
 export const schema = {
   xeroConnections,
+  xeroConnectionStatus,
   settings,
   syncedContacts,
   syncedInvoices,

--- a/src/db/schema/xeroConnectionStatus.schema.ts
+++ b/src/db/schema/xeroConnectionStatus.schema.ts
@@ -1,0 +1,18 @@
+import { boolean, pgTable, timestamp, varchar } from 'drizzle-orm/pg-core'
+import { createSelectSchema } from 'drizzle-zod'
+import type z from 'zod'
+
+// Secret-free mirror of xero_connections.status, one row per portal.
+// Safe to expose to anon via Supabase Realtime — carries no tokenSet/tenantId.
+export const xeroConnectionStatus = pgTable('xero_connection_status', {
+  // Workspace ID / Portal ID in Copilot — one row per portal
+  portalId: varchar({ length: 64 }).primaryKey().notNull(),
+
+  // Connection status, mirrored from xero_connections.status by a DB trigger
+  status: boolean().notNull().default(false),
+
+  updatedAt: timestamp({ withTimezone: true, mode: 'date' }).defaultNow().notNull(),
+})
+
+export const XeroConnectionStatusSchema = createSelectSchema(xeroConnectionStatus)
+export type XeroConnectionStatus = z.infer<typeof XeroConnectionStatusSchema>

--- a/src/features/auth/hooks/useRealtimeXeroConnections.ts
+++ b/src/features/auth/hooks/useRealtimeXeroConnections.ts
@@ -1,18 +1,18 @@
 import { useAuthContext } from '@auth/hooks/useAuth'
-import type { XeroConnection } from '@/db/schema/xeroConnections.schema'
+import type { XeroConnectionStatus } from '@/db/schema/xeroConnectionStatus.schema'
 import type { ClientUser } from '@/lib/copilot/models/ClientUser.model'
 import { useRealtime } from '@/lib/supabase/hooks/useRealtime'
 
 export const useRealtimeXeroConnections = (user: ClientUser) => {
   const { connectionStatus } = useAuthContext()
 
-  return useRealtime<XeroConnection>(
+  return useRealtime<XeroConnectionStatus>(
     user.portalId,
-    'xero_connections',
+    'xero_connection_status',
     `portal_id=eq.${user.portalId}`,
     'UPDATE',
     (payload) => {
-      if (connectionStatus === (payload.new as XeroConnection).status) {
+      if (connectionStatus === (payload.new as XeroConnectionStatus).status) {
         console.info('Skipping auth event...')
         return
       }

--- a/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
+++ b/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
@@ -1,9 +1,15 @@
+BEGIN;
 
--- Revoke all the write permissions from anon and grant select only access on realtime enabled table
+-- Revoke writes, grant select-only to anon
 REVOKE INSERT, UPDATE, DELETE ON xero_connection_status FROM anon;
 GRANT SELECT ON xero_connection_status TO anon;
 
--- Enable RLS in all table at onces using loop
+-- Create the policy before enabling RLS to avoid a default-deny gap
+CREATE POLICY "anon can read connection status"
+  ON xero_connection_status FOR SELECT
+  TO anon USING (true);
+
+-- Enable RLS on all public tables
 do $$
 declare
   r record;
@@ -17,12 +23,8 @@ begin
   end loop;
 end $$;
 
--- Create RLS policy for anon to read the table
-CREATE POLICY "anon can read connection status"
-  ON xero_connection_status FOR SELECT
-  TO anon USING (true);
-
-
--- Realtime: subscribe the new table, drop the old one
+-- Point realtime at the new table
 ALTER PUBLICATION supabase_realtime ADD TABLE xero_connection_status;
 ALTER PUBLICATION supabase_realtime DROP TABLE xero_connections;
+
+COMMIT;

--- a/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
+++ b/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
@@ -1,0 +1,28 @@
+
+-- Revoke all the write permissions from anon and grant select only access on realtime enabled table
+REVOKE INSERT, UPDATE, DELETE ON xero_connection_status FROM anon;
+GRANT SELECT ON xero_connection_status TO anon;
+
+-- Enable RLS in all table at onces using loop
+do $$
+declare
+  r record;
+begin
+  for r in
+    select tablename
+    from pg_tables
+    where schemaname = 'public'
+  loop
+    execute format('alter table public.%I enable row level security;', r.tablename);
+  end loop;
+end $$;
+
+-- Create RLS policy for anon to read the table
+CREATE POLICY "anon can read connection status"
+  ON xero_connection_status FOR SELECT
+  TO anon USING (true);
+
+
+-- Realtime: subscribe the new table, drop the old one
+ALTER PUBLICATION supabase_realtime ADD TABLE xero_connection_status;
+ALTER PUBLICATION supabase_realtime DROP TABLE xero_connections;

--- a/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
+++ b/supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql
@@ -1,7 +1,7 @@
 BEGIN;
 
 -- Revoke writes, grant select-only to anon
-REVOKE INSERT, UPDATE, DELETE ON xero_connection_status FROM anon;
+REVOKE INSERT, UPDATE, DELETE, SELECT ON ALL TABLES IN SCHEMA public FROM anon;
 GRANT SELECT ON xero_connection_status TO anon;
 
 -- Create the policy before enabling RLS to avoid a default-deny gap


### PR DESCRIPTION
## What & why

Closes [OUT-3844](https://linear.app/assemblycom/issue/OUT-3844).

Supabase Realtime currently subscribes to `xero_connections`, whose `tokenSet` column holds the Xero OAuth access + refresh tokens. `postgres_changes` broadcasts the **whole row**, and RLS is row-level (not column-level), so enabling RLS + anon read access to keep realtime working would still leak `tokenSet` to any anon client. The hook only ever reads `status`.

This moves connection status onto a dedicated, secret-free table so RLS + anon realtime can be enabled without exposing tokens.

## Changes

- **New table `xero_connection_status`** (`portal_id` PK, `status`, `updated_at`) — schema + migration.
- **Sync via DB trigger** on `xero_connections` (`AFTER INSERT OR UPDATE`) that upserts `status` into the new table. Guarded by `IS DISTINCT FROM` so token-only writes (refreshes) don't emit needless realtime events. Covers all current and future write paths with no app-code changes.
- **One-time backfill** seeds status rows for existing portals, so their first status change surfaces as a realtime `UPDATE` (the event the hook listens for) rather than a missed `INSERT`.
- **Repoint `useRealtimeXeroConnections`** from `xero_connections` to `xero_connection_status`.
- **RLS snippet** (`supabase/snippets/2026-06-10_rls_and_xero_connection_status.sql`, run manually): enables RLS, grants anon `SELECT` + revokes writes, swaps the realtime publication to the new table, and enables RLS on `xero_connections` (closing anon REST reads).

## Deployment order (important)

The snippet drops `xero_connections` from the realtime publication, so it must run **after** the repointed hook is deployed:

1. Apply the migration (table + trigger + backfill).
2. Deploy this branch (browser now subscribes to `xero_connection_status`).
3. Run the RLS snippet in Supabase.

## Verification

- [ ] Realtime payload carries only `{ portal_id, status, updated_at }` — no `tokenSet`.
- [ ] Connect / disconnect still triggers the redirect.
- [ ] Anon REST read of `xero_connections` returns `[]`.

## Testing Criteria

https://www.loom.com/share/11a10eb005a54d82b524e205f135dbeb

🤖 Generated with [Claude Code](https://claude.com/claude-code)