### PR TITLE
OUT-3868 | OUT-3870: Migrate synced_items to one item per product (drop priceId)

### DIFF
--- a/src/db/migrations/20260612115624_drop_price_id_from_synced_items.sql
+++ b/src/db/migrations/20260612115624_drop_price_id_from_synced_items.sql
@@ -1,0 +1,3 @@
+DROP INDEX "uq_synced_items_portal_id_product_id_price_id";
+CREATE UNIQUE INDEX "uq_synced_items_portal_id_tenant_id_product_id" ON "synced_items" USING btree ("portal_id","tenant_id","product_id");
+ALTER TABLE "synced_items" DROP COLUMN "price_id";

--- a/src/db/migrations/20260615092651_add_product_created_to_failed_syncs_type.sql
+++ b/src/db/migrations/20260615092651_add_product_created_to_failed_syncs_type.sql
@@ -1,0 +1,1 @@
+ALTER TYPE "public"."failed_syncs_type" ADD VALUE 'product.created' BEFORE 'payment.succeeded';

--- a/src/db/migrations/meta/20260612115624_snapshot.json
+++ b/src/db/migrations/meta/20260612115624_snapshot.json
@@ -1,0 +1,941 @@
+{
+  "id": "65dc5418-87f1-4f95-9a25-027b50119fd5",
+  "prevId": "735599a1-fa37-449d-aaa6-5da689e95231",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.failed_syncs": {
+      "name": "failed_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "failed_syncs_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_failed_syncs_resource_id": {
+          "name": "uq_failed_syncs_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_products_automatically": {
+          "name": "sync_products_automatically",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "add_absorbed_fees": {
+          "name": "add_absorbed_fees",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_company_name": {
+          "name": "use_company_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sync_enabled": {
+          "name": "is_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_invoice_settings_mapping": {
+          "name": "initial_invoice_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_product_settings_mapping": {
+          "name": "initial_product_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_settings_portal_id_tenant_id": {
+          "name": "uq_settings_portal_id_tenant_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_date": {
+          "name": "sync_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "sync_logs_event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_logs_status",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "sync_logs_entity_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_id": {
+          "name": "copilot_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_id": {
+          "name": "xero_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_price": {
+          "name": "product_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_item_name": {
+          "name": "xero_item_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_portal_id_tenant_id_created_at": {
+          "name": "idx_sync_logs_portal_id_tenant_id_created_at",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_contacts": {
+      "name": "synced_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_or_company_id": {
+          "name": "client_or_company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "synced_contacts_contact_user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLIENT'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_contacts_portal_id_tenant_id_client_or_company_id": {
+          "name": "uq_synced_contacts_portal_id_tenant_id_client_or_company_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_or_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_invoices": {
+      "name": "synced_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "synced_invoices_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_invoices_portal_id_copilot_invoice_id": {
+          "name": "uq_synced_invoices_portal_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_items": {
+      "name": "synced_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_items_portal_id_tenant_id_product_id": {
+          "name": "uq_synced_items_portal_id_tenant_id_product_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_payments": {
+      "name": "synced_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_payment_id": {
+          "name": "copilot_payment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_payment_id": {
+          "name": "xero_payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "synced_payments_payment_type",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'payment'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id": {
+          "name": "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_synced_payments_xero_payment_id": {
+          "name": "uq_synced_payments_xero_payment_id",
+          "columns": [
+            {
+              "expression": "xero_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connection_status": {
+      "name": "xero_connection_status",
+      "schema": "",
+      "columns": {
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connections": {
+      "name": "xero_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_set": {
+          "name": "token_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_xero_connections_portal_id": {
+          "name": "uq_xero_connections_portal_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.failed_syncs_type": {
+      "name": "failed_syncs_type",
+      "schema": "public",
+      "values": [
+        "invoice.created",
+        "invoice.updated",
+        "invoice.paid",
+        "invoice.voided",
+        "invoice.deleted",
+        "product.updated",
+        "price.created",
+        "payment.succeeded"
+      ]
+    },
+    "public.sync_logs_entity_type": {
+      "name": "sync_logs_entity_type",
+      "schema": "public",
+      "values": ["invoice", "customer", "product", "expense"]
+    },
+    "public.sync_logs_event_type": {
+      "name": "sync_logs_event_type",
+      "schema": "public",
+      "values": ["created", "mapped", "unmapped", "paid", "voided", "updated", "deleted"]
+    },
+    "public.sync_logs_status": {
+      "name": "sync_logs_status",
+      "schema": "public",
+      "values": ["success", "failed", "info"]
+    },
+    "public.synced_invoices_status": {
+      "name": "synced_invoices_status",
+      "schema": "public",
+      "values": ["pending", "failed", "success"]
+    },
+    "public.synced_payments_payment_type": {
+      "name": "synced_payments_payment_type",
+      "schema": "public",
+      "values": ["payment", "expense"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/20260615092651_snapshot.json
+++ b/src/db/migrations/meta/20260615092651_snapshot.json
@@ -1,0 +1,942 @@
+{
+  "id": "9a94dee7-83f7-40d2-aa07-42e9be860ec0",
+  "prevId": "65dc5418-87f1-4f95-9a25-027b50119fd5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.failed_syncs": {
+      "name": "failed_syncs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "failed_syncs_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "varchar(1024)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource_id": {
+          "name": "resource_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_failed_syncs_resource_id": {
+          "name": "uq_failed_syncs_resource_id",
+          "columns": [
+            {
+              "expression": "resource_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "country_code": {
+          "name": "country_code",
+          "type": "varchar(8)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_products_automatically": {
+          "name": "sync_products_automatically",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "add_absorbed_fees": {
+          "name": "add_absorbed_fees",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "use_company_name": {
+          "name": "use_company_name",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "is_sync_enabled": {
+          "name": "is_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_invoice_settings_mapping": {
+          "name": "initial_invoice_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initial_product_settings_mapping": {
+          "name": "initial_product_settings_mapping",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_settings_portal_id_tenant_id": {
+          "name": "uq_settings_portal_id_tenant_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_logs": {
+      "name": "sync_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_date": {
+          "name": "sync_date",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "sync_logs_event_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "sync_logs_status",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "sync_logs_entity_type",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_id": {
+          "name": "copilot_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_id": {
+          "name": "xero_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invoice_number": {
+          "name": "invoice_number",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_name": {
+          "name": "customer_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "customer_email": {
+          "name": "customer_email",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tax_amount": {
+          "name": "tax_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fee_amount": {
+          "name": "fee_amount",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "product_price": {
+          "name": "product_price",
+          "type": "numeric",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_item_name": {
+          "name": "xero_item_name",
+          "type": "varchar(512)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "idx_sync_logs_portal_id_tenant_id_created_at": {
+          "name": "idx_sync_logs_portal_id_tenant_id_created_at",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "\"created_at\" desc",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_contacts": {
+      "name": "synced_contacts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_or_company_id": {
+          "name": "client_or_company_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_type": {
+          "name": "user_type",
+          "type": "synced_contacts_contact_user_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'CLIENT'"
+        },
+        "contact_id": {
+          "name": "contact_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_contacts_portal_id_tenant_id_client_or_company_id": {
+          "name": "uq_synced_contacts_portal_id_tenant_id_client_or_company_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "client_or_company_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_invoices": {
+      "name": "synced_invoices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "synced_invoices_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_invoices_portal_id_copilot_invoice_id": {
+          "name": "uq_synced_invoices_portal_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_items": {
+      "name": "synced_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_items_portal_id_tenant_id_product_id": {
+          "name": "uq_synced_items_portal_id_tenant_id_product_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "product_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.synced_payments": {
+      "name": "synced_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_invoice_id": {
+          "name": "copilot_invoice_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "xero_invoice_id": {
+          "name": "xero_invoice_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "copilot_payment_id": {
+          "name": "copilot_payment_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "xero_payment_id": {
+          "name": "xero_payment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "synced_payments_payment_type",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'payment'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id": {
+          "name": "uq_synced_payments_portal_id_tenant_id_copilot_invoice_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "tenant_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "copilot_invoice_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_synced_payments_xero_payment_id": {
+          "name": "uq_synced_payments_xero_payment_id",
+          "columns": [
+            {
+              "expression": "xero_payment_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connection_status": {
+      "name": "xero_connection_status",
+      "schema": "",
+      "columns": {
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.xero_connections": {
+      "name": "xero_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "portal_id": {
+          "name": "portal_id",
+          "type": "varchar(64)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tenant_id": {
+          "name": "tenant_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_set": {
+          "name": "token_set",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "initiated_by": {
+          "name": "initiated_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_xero_connections_portal_id": {
+          "name": "uq_xero_connections_portal_id",
+          "columns": [
+            {
+              "expression": "portal_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.failed_syncs_type": {
+      "name": "failed_syncs_type",
+      "schema": "public",
+      "values": [
+        "invoice.created",
+        "invoice.updated",
+        "invoice.paid",
+        "invoice.voided",
+        "invoice.deleted",
+        "product.updated",
+        "price.created",
+        "product.created",
+        "payment.succeeded"
+      ]
+    },
+    "public.sync_logs_entity_type": {
+      "name": "sync_logs_entity_type",
+      "schema": "public",
+      "values": ["invoice", "customer", "product", "expense"]
+    },
+    "public.sync_logs_event_type": {
+      "name": "sync_logs_event_type",
+      "schema": "public",
+      "values": ["created", "mapped", "unmapped", "paid", "voided", "updated", "deleted"]
+    },
+    "public.sync_logs_status": {
+      "name": "sync_logs_status",
+      "schema": "public",
+      "values": ["success", "failed", "info"]
+    },
+    "public.synced_invoices_status": {
+      "name": "synced_invoices_status",
+      "schema": "public",
+      "values": ["pending", "failed", "success"]
+    },
+    "public.synced_payments_payment_type": {
+      "name": "synced_payments_payment_type",
+      "schema": "public",
+      "values": ["payment", "expense"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1781265384050,
       "tag": "20260612115624_drop_price_id_from_synced_items",
       "breakpoints": false
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1781515611991,
+      "tag": "20260615092651_add_product_created_to_failed_syncs_type",
+      "breakpoints": false
     }
   ]
 }

--- a/src/db/migrations/meta/_journal.json
+++ b/src/db/migrations/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1781085433576,
       "tag": "20260610095713_add_xero_connection_status",
       "breakpoints": false
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1781265384050,
+      "tag": "20260612115624_drop_price_id_from_synced_items",
+      "breakpoints": false
     }
   ]
 }

--- a/src/db/schema/failedSyncs.schema.ts
+++ b/src/db/schema/failedSyncs.schema.ts
@@ -9,7 +9,9 @@ export const failedSyncTypeEnum = pgEnum('failed_syncs_type', [
   ValidWebhookEvent.InvoiceVoided,
   ValidWebhookEvent.InvoiceDeleted,
   ValidWebhookEvent.ProductUpdated,
+  // Legacy: no longer emitted, kept so historical failed_syncs rows stay valid
   ValidWebhookEvent.PriceCreated,
+  ValidWebhookEvent.ProductCreated,
   ValidWebhookEvent.PaymentSucceeded,
 ])
 

--- a/src/db/schema/syncedItems.schema.ts
+++ b/src/db/schema/syncedItems.schema.ts
@@ -17,20 +17,17 @@ export const syncedItems = pgTable(
     // Product ID for Copilot
     productId: varchar({ length: 64 }).notNull(),
 
-    // Price ID for corresponding Copilot product
-    priceId: varchar({ length: 64 }).notNull(),
-
     // Item ID for synced Item in Xero
     itemId: uuid().notNull(),
 
     ...timestamps,
   },
   (t) => [
-    // One product x price combination for a portal should have ONLY ONE synced item in Xero
-    uniqueIndex('uq_synced_items_portal_id_product_id_price_id').on(
+    // One product for a portal/tenant should have ONLY ONE synced item in Xero
+    uniqueIndex('uq_synced_items_portal_id_tenant_id_product_id').on(
       t.portalId,
+      t.tenantId,
       t.productId,
-      t.priceId,
     ),
   ],
 )

--- a/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
+++ b/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
@@ -1,10 +1,12 @@
 import AuthService from '@auth/lib/Auth.service'
 import { MAX_RETRY_ATTEMPTS } from '@failed-syncs/lib/constants'
+import { ValidWebhookEvent } from '@invoice-sync/types'
 import WebhookService from '@webhook/lib/webhook.service'
 import { eq, lte } from 'drizzle-orm'
 import env from '@/config/server.env'
 import db from '@/db'
 import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import { CopilotAPI } from '@/lib/copilot/CopilotAPI'
 import User from '@/lib/copilot/models/User.model'
 import logger from '@/lib/logger'
 import { encodePayload } from '@/utils/crypto'
@@ -37,6 +39,37 @@ class RetryFailedSyncsService {
         logger.info('Found connection', connection.id)
 
         const webhookService = new WebhookService(user, connection)
+
+        // Legacy price.created failed syncs are resolved as product.created (one Xero item per
+        // product). Their stored payload is a price event, so resolve the product from productId.
+        if (failedSync.type === ValidWebhookEvent.PriceCreated) {
+          const { productId } = (failedSync.payload ?? {}) as { productId?: string }
+          if (!productId) {
+            logger.warn(
+              'Legacy price.created failed sync has no productId, dropping',
+              failedSync.id,
+            )
+            await db.delete(failedSyncs).where(eq(failedSyncs.id, failedSync.id))
+            continue
+          }
+
+          // Fetch first: a transient failure here keeps the row for a later retry
+          const products = await new CopilotAPI(token).getProductsMapById([productId])
+          const product = products[productId]
+
+          // Drop the legacy row before dispatching: if handleEvent fails it records its own
+          // product.created retry, so the price.created row must not linger and reprocess.
+          await db.delete(failedSyncs).where(eq(failedSyncs.id, failedSync.id))
+
+          if (product) {
+            await webhookService.handleEvent({
+              eventType: ValidWebhookEvent.ProductCreated,
+              data: { id: product.id, name: product.name, description: product.description },
+            })
+          }
+          continue
+        }
+
         await webhookService.handleEvent({
           eventType: failedSync.type,
           // biome-ignore lint/suspicious/noExplicitAny: payload can literally be anything

--- a/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
+++ b/src/features/failed-syncs/lib/RetryFailedSyncs.service.ts
@@ -40,8 +40,7 @@ class RetryFailedSyncsService {
 
         const webhookService = new WebhookService(user, connection)
 
-        // Legacy price.created failed syncs are resolved as product.created (one Xero item per
-        // product). Their stored payload is a price event, so resolve the product from productId.
+        // Resolve legacy price.created records as product.created via the payload's productId
         if (failedSync.type === ValidWebhookEvent.PriceCreated) {
           const { productId } = (failedSync.payload ?? {}) as { productId?: string }
           if (!productId) {
@@ -53,20 +52,24 @@ class RetryFailedSyncsService {
             continue
           }
 
-          // Fetch first: a transient failure here keeps the row for a later retry
           const products = await new CopilotAPI(token).getProductsMapById([productId])
           const product = products[productId]
-
-          // Drop the legacy row before dispatching: if handleEvent fails it records its own
-          // product.created retry, so the price.created row must not linger and reprocess.
-          await db.delete(failedSyncs).where(eq(failedSyncs.id, failedSync.id))
-
-          if (product) {
-            await webhookService.handleEvent({
-              eventType: ValidWebhookEvent.ProductCreated,
-              data: { id: product.id, name: product.name, description: product.description },
-            })
+          if (!product) {
+            logger.warn(
+              'Legacy price.created failed sync references a product that no longer exists, dropping',
+              failedSync.id,
+              productId,
+            )
+            await db.delete(failedSyncs).where(eq(failedSyncs.id, failedSync.id))
+            continue
           }
+
+          // Delete only after a successful dispatch, like every other event — no row loss on failure
+          await webhookService.handleEvent({
+            eventType: ValidWebhookEvent.ProductCreated,
+            data: { id: product.id, name: product.name, description: product.description },
+          })
+          await db.delete(failedSyncs).where(eq(failedSyncs.id, failedSync.id))
           continue
         }
 

--- a/src/features/invoice-sync/lib/SyncedInvoices.service.ts
+++ b/src/features/invoice-sync/lib/SyncedInvoices.service.ts
@@ -61,7 +61,7 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
 
     const taxRatePromise = this.getTaxRate(data, regionConfig)
     const contactPromise = this.getContact(data)
-    const priceIdToXeroItemPromise = this.getPriceIdToXeroItem(data)
+    const productIdToXeroItemPromise = this.getProductIdToXeroItem(data)
 
     // Xero rejects an invoice line whose accountCode doesn't exist in the org's chart of accounts
     const syncedAccountsService = new SyncedAccountsService(this.user, this.connection)
@@ -70,15 +70,15 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
     const [
       taxRate,
       { contactID, emailAddress: customerEmail, name: customerName },
-      priceIdToXeroItem,
+      productIdToXeroItem,
     ] = await Promise.all([
       taxRatePromise,
       contactPromise,
-      priceIdToXeroItemPromise,
+      productIdToXeroItemPromise,
       salesAccountPromise,
     ])
 
-    const lineItems = serializeLineItems(data.lineItems, priceIdToXeroItem, regionConfig, taxRate)
+    const lineItems = serializeLineItems(data.lineItems, productIdToXeroItem, regionConfig, taxRate)
     if (!lineItems.length) {
       logger.info('No valid line items to sync to Xero invoice. Skipping sync...')
       return {
@@ -457,27 +457,27 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
   }
 
   /**
-   * Creates a mapping of priceId to Xero Item for all line items in the invoice.
+   * Creates a mapping of productId to Xero Item for all line items in the invoice.
    * Uses the `syncProductsAutomatically` setting to determine whether to create new items in Xero or create a service invoice.
    */
-  private async getPriceIdToXeroItem(data: InvoiceCreatedEvent): Promise<Record<string, Item>> {
+  private async getProductIdToXeroItem(data: InvoiceCreatedEvent): Promise<Record<string, Item>> {
     logger.info(
-      'SyncedInvoicesService#getPriceIdToXeroItem :: Getting priceId to xero item for line items...',
+      'SyncedInvoicesService#getProductIdToXeroItem :: Getting productId to xero item for line items...',
     )
 
     const syncedItemsService = new SyncedItemsService(this.user, this.connection)
     const [xeroItems, syncedItemsMap] = await Promise.all([
       this.xero.getItems(this.connection.tenantId),
-      syncedItemsService.getSyncedItemsMapByPriceIds('all'),
+      syncedItemsService.getSyncedItemsMapByProductIds('all'),
     ])
     // const [xeroItems, syncedItemsMap, products, prices] = await Promise.all([
     //   this.xero.getItems(this.connection.tenantId),
-    //   syncedItemsService.getSyncedItemsMapByPriceIds('all'),
+    //   syncedItemsService.getSyncedItemsMapByProductIds('all'),
     //   this.copilot.getProductsMapById('all'),
     //   this.copilot.getPricesMapById('all'),
     // ])
 
-    const priceIdToXeroItem: Record<string, Item> = {}
+    const productIdToXeroItem: Record<string, Item> = {}
 
     // NOTE: IMPORTANT:
     // Uncomment commented lines if we want previously unsynced items to create new items on invoice creation
@@ -486,14 +486,14 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
     // const itemCodeToPriceMap: Record<string, CopilotPrice> = {}
 
     for (const item of data.lineItems) {
-      if (!item.productId || !item.priceId) continue
+      if (!item.productId) continue
 
-      // Case I: For line item with productId & priceId, if synced product exists, use it
-      const matchedXeroItemId = syncedItemsMap[item.priceId]?.itemId
+      // Case I: For line item with productId, if synced product exists, use it
+      const matchedXeroItemId = syncedItemsMap[item.productId]?.itemId
       if (matchedXeroItemId) {
         const xeroItem = xeroItems.find((i) => i.itemID === matchedXeroItemId)
         if (xeroItem) {
-          priceIdToXeroItem[item.priceId] = xeroItem
+          productIdToXeroItem[item.productId] = xeroItem
           // continue
         }
       }
@@ -540,7 +540,7 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
     //   }
     // }
 
-    return priceIdToXeroItem
+    return productIdToXeroItem
   }
 
   async getOrCreateInvoiceRecord(

--- a/src/features/invoice-sync/lib/SyncedInvoices.service.ts
+++ b/src/features/invoice-sync/lib/SyncedInvoices.service.ts
@@ -497,48 +497,7 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
           // continue
         }
       }
-
-      // CASE II: If synced product doesn't exist, create new ones
-      // const code = genRandomString(12)
-      // const copilotProduct = products[item.productId]
-      // const copilotPrice = prices[item.priceId]
-      //
-      // logger.info(
-      //   'XeroInvoiceSyncService#getPriceIdToXeroItem :: Creating new item for lineItem',
-      //   item.description,
-      //   {
-      //     copilotProduct,
-      //     copilotPrice,
-      //   },
-      // )
-      // itemsToCreate.push({
-      //   code,
-      //   name: copilotProduct.name,
-      //   description: htmlToText(copilotProduct.description),
-      //   isPurchased: false,
-      //   salesDetails: {
-      //     unitPrice: copilotPrice.amount / 100,
-      //   },
-      // })
-      // itemCodeToPriceMap[code] = copilotPrice
     }
-
-    // Create missing items in Xero
-    // if (itemsToCreate.length) {
-    //   logger.info(
-    //     'XeroInvoiceService#getPriceIdToXeroItem :: Did not find these synced items. Creating new items and syncing them...',
-    //     itemsToCreate,
-    //   )
-    //
-    //   const newlyCreatedItems = await syncedItemsService.createItems(
-    //     itemsToCreate,
-    //     itemCodeToPriceMap,
-    //   )
-    //   for (const item of newlyCreatedItems) {
-    //     const price = itemCodeToPriceMap[item.code]
-    //     priceIdToXeroItem[price.id] = item
-    //   }
-    // }
 
     return productIdToXeroItem
   }

--- a/src/features/invoice-sync/lib/serializers.ts
+++ b/src/features/invoice-sync/lib/serializers.ts
@@ -14,19 +14,19 @@ import {
 
 export const serializeLineItems = (
   copilotItems: InvoiceCreatedEvent['lineItems'],
-  priceIdToXeroItem: Record<string, Item>,
+  productIdToXeroItem: Record<string, Item>,
   regionConfig: RegionConfig,
   taxRate?: TaxRate,
 ): LineItem[] => {
   logger.info('invoice-sync/lib/serializers#serializeLineItems :: Serializing line items:', {
     copilotItems,
-    priceIdToXeroItem,
+    productIdToXeroItem,
     taxRate,
   })
 
   const xeroLineItems: LineItem[] = []
   for (const item of copilotItems) {
-    const xeroItem = item.priceId ? priceIdToXeroItem[item.priceId] : undefined
+    const xeroItem = item.productId ? productIdToXeroItem[item.productId] : undefined
 
     const payload = {
       // NOTE: Both lineItemID and itemCode need to be provided for an invoice item to map to an item in Xero

--- a/src/features/invoice-sync/types.ts
+++ b/src/features/invoice-sync/types.ts
@@ -42,19 +42,18 @@ export const InvoiceModifiedEventSchema = z.object({
   id: z.string(),
 })
 
-export const ProductUpdatedEventSchema = z.object({
+// product.created and product.updated carry the same shape
+export const ProductEventSchema = z.object({
   id: z.string(),
   name: z.string(),
   description: z.string(),
 })
+
+export const ProductUpdatedEventSchema = ProductEventSchema
 export type ProductUpdatedEvent = z.infer<typeof ProductUpdatedEventSchema>
 
-export const PriceCreatedEventSchema = z.object({
-  id: z.string(),
-  productId: z.string(),
-  amount: z.number(),
-})
-export type PriceCreatedEvent = z.infer<typeof PriceCreatedEventSchema>
+export const ProductCreatedEventSchema = ProductEventSchema
+export type ProductCreatedEvent = z.infer<typeof ProductCreatedEventSchema>
 
 export enum PaymentStatus {
   PENDING = 'pending',
@@ -84,6 +83,8 @@ export enum ValidWebhookEvent {
   InvoiceVoided = 'invoice.voided',
   InvoiceDeleted = 'invoice.deleted',
   ProductUpdated = 'product.updated',
+  ProductCreated = 'product.created',
+  // Legacy: retained for historical failed_syncs records; no longer handled as a live webhook
   PriceCreated = 'price.created',
   PaymentSucceeded = 'payment.succeeded',
 }
@@ -124,11 +125,11 @@ export const ProductUpdatedWebhookSchema = z.object({
 })
 export type ProductUpdatedWebhook = z.infer<typeof ProductUpdatedWebhookSchema>
 
-export const PriceCreatedWebhookSchema = z.object({
-  eventType: z.literal(ValidWebhookEvent.PriceCreated),
-  data: PriceCreatedEventSchema,
+export const ProductCreatedWebhookSchema = z.object({
+  eventType: z.literal(ValidWebhookEvent.ProductCreated),
+  data: ProductCreatedEventSchema,
 })
-export type PriceCreatedWebhook = z.infer<typeof PriceCreatedWebhookSchema>
+export type ProductCreatedWebhook = z.infer<typeof ProductCreatedWebhookSchema>
 
 export const PaymentSucceededWebhookSchema = z.object({
   eventType: z.literal(ValidWebhookEvent.PaymentSucceeded),
@@ -142,7 +143,7 @@ export const WebhookEventSchema = z.discriminatedUnion('eventType', [
   InvoiceVoidedWebhookSchema,
   InvoiceDeletedWebhookSchema,
   ProductUpdatedWebhookSchema,
-  PriceCreatedWebhookSchema,
+  ProductCreatedWebhookSchema,
   PaymentSucceededWebhookSchema,
 ])
 export type WebhookEvent = z.infer<typeof WebhookEventSchema>

--- a/src/features/items-sync/lib/SyncedItems.service.ts
+++ b/src/features/items-sync/lib/SyncedItems.service.ts
@@ -28,26 +28,45 @@ class SyncedItemsService extends AuthenticatedXeroService {
     if (!itemsToCreate.length) return []
 
     const newlyCreatedItems = await this.xero.createItems(this.connection.tenantId, itemsToCreate)
-    await this.db
+
+    const insertPayloads = newlyCreatedItems.map((item) => ({
+      portalId: this.user.portalId,
+      productId: productIdForCode[item.code],
+      itemId: z.uuid().parse(item.itemID),
+      tenantId: this.connection.tenantId,
+    }))
+    logger.info('SyncedItemsService#createItems :: Inserting synced item records:', insertPayloads)
+
+    // Ignore on conflict (product already mapped); returning() shows which rows won
+    const inserted = await this.db
       .insert(syncedItems)
-      .values(
-        newlyCreatedItems.map((item) => {
-          const insertPayload = {
-            portalId: this.user.portalId,
-            productId: productIdForCode[item.code],
-            itemId: z.uuid().parse(item.itemID),
-            tenantId: this.connection.tenantId,
-          }
-          logger.info(
-            'SyncedItemsService#createItems :: Inserting synced item record:',
-            insertPayload,
-          )
-          return insertPayload
-        }),
-      )
-      // One item per product: ignore if this product was already mapped (race safety)
+      .values(insertPayloads)
       .onConflictDoNothing()
-    return newlyCreatedItems
+      .returning({ itemId: syncedItems.itemId })
+    const insertedItemIds = new Set(inserted.map((row) => row.itemId))
+
+    // Delete Xero items whose mapping lost the conflict — orphans we just created
+    const persistedItems: Item[] = []
+    for (const item of newlyCreatedItems) {
+      if (insertedItemIds.has(z.uuid().parse(item.itemID))) {
+        persistedItems.push(item)
+        continue
+      }
+      logger.warn(
+        'SyncedItemsService#createItems :: Product already mapped, deleting orphaned Xero item',
+        item.itemID,
+      )
+      try {
+        await this.xero.deleteItem(this.connection.tenantId, z.uuid().parse(item.itemID))
+      } catch (error) {
+        logger.error(
+          'SyncedItemsService#createItems :: Failed to delete orphaned Xero item',
+          item.itemID,
+          error,
+        )
+      }
+    }
+    return persistedItems
   }
 
   /**
@@ -180,6 +199,8 @@ class SyncedItemsService extends AuthenticatedXeroService {
 
       try {
         const items = await this.createItems([payload], { [payload.code]: product.id })
+        // Lost the create race; orphan already cleaned up
+        if (!items.length) continue
         createdItems.push(items[0])
 
         await syncLogsService.createSyncLog({

--- a/src/features/items-sync/lib/SyncedItems.service.ts
+++ b/src/features/items-sync/lib/SyncedItems.service.ts
@@ -30,7 +30,6 @@ class SyncedItemsService extends AuthenticatedXeroService {
         const insertPayload = {
           portalId: this.user.portalId,
           productId: price.productId,
-          priceId: price.id,
           itemId: z.uuid().parse(item.itemID),
           tenantId: this.connection.tenantId,
         }
@@ -45,26 +44,28 @@ class SyncedItemsService extends AuthenticatedXeroService {
   }
 
   /**
-   * Returns a list of Mappable items where the key is the priceId
+   * Returns a list of Mappable items where the key is the productId
    */
-  async getSyncedItemsMapByPriceIds(priceIds: string[] | 'all'): Promise<Record<string, Mappable>> {
+  async getSyncedItemsMapByProductIds(
+    productIds: string[] | 'all',
+  ): Promise<Record<string, Mappable>> {
     logger.info(
-      'SyncedItemsService#getSyncedItemsMapByPriceIds :: Getting synced items map for priceIds',
-      priceIds,
+      'SyncedItemsService#getSyncedItemsMapByProductIds :: Getting synced items map for productIds',
+      productIds,
     )
 
     const dbMappings = await this.db
-      .select(getTableFields(syncedItems, ['productId', 'priceId', 'itemId']))
+      .select(getTableFields(syncedItems, ['productId', 'itemId']))
       .from(syncedItems)
       .where(
         and(
           eq(syncedItems.portalId, this.user.portalId),
           eq(syncedItems.tenantId, this.connection.tenantId),
-          priceIds === 'all' ? undefined : inArray(syncedItems.priceId, priceIds),
+          productIds === 'all' ? undefined : inArray(syncedItems.productId, productIds),
         ),
       )
     return dbMappings.reduce<Record<string, (typeof dbMappings)[0]>>((acc, mapping) => {
-      acc[mapping.priceId] = mapping
+      acc[mapping.productId] = mapping
       return acc
     }, {})
   }
@@ -111,9 +112,8 @@ class SyncedItemsService extends AuthenticatedXeroService {
         })
         items.push(updatedItem)
 
-        const { copilotProduct, copilotPrice, xeroItem } = await this.getCopilotProductAndPrice(
+        const { copilotProduct, xeroItem } = await this.getCopilotProductAndXeroItem(
           item.productId,
-          item.priceId,
           item.itemId,
         )
 
@@ -126,7 +126,6 @@ class SyncedItemsService extends AuthenticatedXeroService {
           xeroId: item.itemId,
           xeroItemName: xeroItem?.name,
           productName: copilotProduct?.name,
-          productPrice: String((copilotPrice?.amount || 0) / 100),
         })
       } catch (error: unknown) {
         throw new APIError('Failed to update synced item', status.INTERNAL_SERVER_ERROR, {
@@ -221,13 +220,11 @@ class SyncedItemsService extends AuthenticatedXeroService {
         portalId: this.user.portalId,
         tenantId: this.connection.tenantId,
         productId: item.productId,
-        priceId: item.priceId,
         itemId: item.itemId,
       })
 
-      const { copilotProduct, copilotPrice, xeroItem } = await this.getCopilotProductAndPrice(
+      const { copilotProduct, xeroItem } = await this.getCopilotProductAndXeroItem(
         item.productId,
-        item.priceId,
         item.itemId,
       )
       await syncLogsService.createSyncLog({
@@ -238,7 +235,6 @@ class SyncedItemsService extends AuthenticatedXeroService {
         copilotId: item.productId,
         xeroId: item.itemId,
         productName: copilotProduct?.name,
-        productPrice: String((copilotPrice?.amount || 0) / 100),
         xeroItemName: xeroItem?.name,
       })
     }
@@ -267,13 +263,11 @@ class SyncedItemsService extends AuthenticatedXeroService {
             eq(syncedItems.portalId, this.user.portalId),
             eq(syncedItems.tenantId, this.connection.tenantId),
             eq(syncedItems.productId, item.productId),
-            eq(syncedItems.priceId, item.priceId),
             eq(syncedItems.itemId, item.itemId),
           ),
         )
-      const { copilotProduct, copilotPrice, xeroItem } = await this.getCopilotProductAndPrice(
+      const { copilotProduct, xeroItem } = await this.getCopilotProductAndXeroItem(
         item.productId,
-        item.priceId,
         item.itemId,
       )
       await syncLogsService.createSyncLog({
@@ -284,28 +278,22 @@ class SyncedItemsService extends AuthenticatedXeroService {
         copilotId: item.productId,
         xeroId: item.itemId,
         productName: copilotProduct?.name,
-        productPrice: String((copilotPrice?.amount || 0) / 100),
         xeroItemName: xeroItem?.name,
       })
     }
   }
 
-  private async getCopilotProductAndPrice(productId: string, priceId: string, itemId: string) {
+  private async getCopilotProductAndXeroItem(productId: string, itemId: string) {
     try {
-      const copilotProductMapPromise = this.copilot.getProductsMapById([productId])
-      const copilotPriceMapPromise = this.copilot.getPricesMapById([priceId])
-      const xeroItemMapPromise = this.xero.getItemsMap(this.connection.tenantId)
-      const [copilotProductMap, copilotPriceMap, xeroItemMap] = await Promise.all([
-        copilotProductMapPromise,
-        copilotPriceMapPromise,
-        xeroItemMapPromise,
+      const [copilotProductMap, xeroItemMap] = await Promise.all([
+        this.copilot.getProductsMapById([productId]),
+        this.xero.getItemsMap(this.connection.tenantId),
       ])
       const copilotProduct = copilotProductMap[productId]
-      const copilotPrice = copilotPriceMap[priceId]
       const xeroItem = xeroItemMap[itemId]
-      return { copilotProduct, copilotPrice, xeroItem }
+      return { copilotProduct, xeroItem }
     } catch (_) {
-      return { copilotProduct: null, copilotPrice: null, xeroItem: null }
+      return { copilotProduct: null, xeroItem: null }
     }
   }
 }

--- a/src/features/items-sync/lib/SyncedItems.service.ts
+++ b/src/features/items-sync/lib/SyncedItems.service.ts
@@ -1,6 +1,6 @@
 import 'server-only'
 
-import type { PriceCreatedEvent } from '@invoice-sync/types'
+import type { ProductCreatedEvent } from '@invoice-sync/types'
 import type { Mappable } from '@items-sync/types'
 import { SyncLogsService } from '@sync-logs/lib/SyncLogs.service'
 import { and, eq, inArray } from 'drizzle-orm'
@@ -18,28 +18,35 @@ import { htmlToText } from '@/utils/html'
 import { genRandomString } from '@/utils/string'
 
 class SyncedItemsService extends AuthenticatedXeroService {
-  async createItems(itemsToCreate: Item[], pricesForCode: Record<string, PriceCreatedEvent>) {
-    logger.info('SyncedItemsService#createItems :: Creating items:', itemsToCreate, pricesForCode)
+  async createItems(itemsToCreate: Item[], productIdForCode: Record<string, string>) {
+    logger.info(
+      'SyncedItemsService#createItems :: Creating items:',
+      itemsToCreate,
+      productIdForCode,
+    )
 
     if (!itemsToCreate.length) return []
 
     const newlyCreatedItems = await this.xero.createItems(this.connection.tenantId, itemsToCreate)
-    await this.db.insert(syncedItems).values(
-      newlyCreatedItems.map((item) => {
-        const price = pricesForCode[item.code]
-        const insertPayload = {
-          portalId: this.user.portalId,
-          productId: price.productId,
-          itemId: z.uuid().parse(item.itemID),
-          tenantId: this.connection.tenantId,
-        }
-        logger.info(
-          'SyncedItemsService#createItems :: Inserting synced item record:',
-          insertPayload,
-        )
-        return insertPayload
-      }),
-    )
+    await this.db
+      .insert(syncedItems)
+      .values(
+        newlyCreatedItems.map((item) => {
+          const insertPayload = {
+            portalId: this.user.portalId,
+            productId: productIdForCode[item.code],
+            itemId: z.uuid().parse(item.itemID),
+            tenantId: this.connection.tenantId,
+          }
+          logger.info(
+            'SyncedItemsService#createItems :: Inserting synced item record:',
+            insertPayload,
+          )
+          return insertPayload
+        }),
+      )
+      // One item per product: ignore if this product was already mapped (race safety)
+      .onConflictDoNothing()
     return newlyCreatedItems
   }
 
@@ -142,34 +149,37 @@ class SyncedItemsService extends AuthenticatedXeroService {
     return items
   }
 
-  async createSyncedItemsForPrices(prices: PriceCreatedEvent[]): Promise<Item[]> {
+  async createSyncedItemsForProducts(products: ProductCreatedEvent[]): Promise<Item[]> {
     logger.info(
-      'SyncedItemsService#createSyncedItemsForPrices :: Creating synced items for prices',
-      prices,
+      'SyncedItemsService#createSyncedItemsForProducts :: Creating synced items for products',
+      products,
     )
     const createdItems: Item[] = []
 
-    for (const price of prices) {
-      const productMap = await this.copilot.getProductsMapById([price.productId])
-      const product = productMap[price.productId]
-      if (!product) {
-        throw new APIError('Could not find product for mapping', status.BAD_REQUEST)
+    // One Xero Item per product: skip products that are already mapped
+    const existingMappings = await this.getSyncedItemsMapByProductIds(products.map((p) => p.id))
+
+    for (const product of products) {
+      if (existingMappings[product.id]) {
+        logger.info(
+          'SyncedItemsService#createSyncedItemsForProducts :: Product already mapped, skipping',
+          product.id,
+        )
+        continue
       }
 
+      // No unitPrice: created items carry no price, invoice lines always supply it
       const payload = {
         code: genRandomString(12),
         name: product.name,
         description: htmlToText(product.description),
         isPurchased: false,
-        salesDetails: {
-          unitPrice: price.amount / 100,
-        },
       }
 
       const syncLogsService = new SyncLogsService(this.user, this.connection)
 
       try {
-        const items = await this.createItems([payload], { [payload.code]: price })
+        const items = await this.createItems([payload], { [payload.code]: product.id })
         createdItems.push(items[0])
 
         await syncLogsService.createSyncLog({
@@ -177,23 +187,25 @@ class SyncedItemsService extends AuthenticatedXeroService {
           eventType: SyncEventType.CREATED,
           status: SyncStatus.SUCCESS,
           syncDate: new Date(),
-          copilotId: price.productId,
+          copilotId: product.id,
           xeroId: items[0].itemID,
           xeroItemName: items[0].name,
           productName: product.name,
-          productPrice: String(price.amount / 100),
         })
       } catch (error: unknown) {
-        throw new APIError('Failed to create synced item for price', status.INTERNAL_SERVER_ERROR, {
-          error,
-          failedSyncLogPayload: {
-            entityType: SyncEntityType.PRODUCT,
-            eventType: SyncEventType.CREATED,
-            copilotId: price.productId,
-            productName: product.name,
-            productPrice: String(price.amount / 100),
+        throw new APIError(
+          'Failed to create synced item for product',
+          status.INTERNAL_SERVER_ERROR,
+          {
+            error,
+            failedSyncLogPayload: {
+              entityType: SyncEntityType.PRODUCT,
+              eventType: SyncEventType.CREATED,
+              copilotId: product.id,
+              productName: product.name,
+            },
           },
-        })
+        )
       }
     }
     return createdItems
@@ -204,7 +216,7 @@ class SyncedItemsService extends AuthenticatedXeroService {
 
     const syncLogsService = new SyncLogsService(this.user, this.connection)
 
-    // We have to do this one-by-one because xero doesn't provide a bulk delete API
+    // One-by-one so we can write a sync log per mapping
     for (const item of items) {
       logger.info('SyncedItemsService#addSyncedItems :: Adding mapping', item)
 
@@ -213,7 +225,7 @@ class SyncedItemsService extends AuthenticatedXeroService {
           'SyncedItemsService#addSyncedItem :: Attempted to add non existant itemId for ',
           item,
         )
-        return
+        continue
       }
 
       await this.db.insert(syncedItems).values({
@@ -244,7 +256,7 @@ class SyncedItemsService extends AuthenticatedXeroService {
     logger.info('SyncedItemsService#deleteSyncedItems :: Deleting synced items', items)
     const syncLogsService = new SyncLogsService(this.user, this.connection)
 
-    // We have to do this one-by-one because xero doesn't provide a bulk delete API
+    // One-by-one so we can write a sync log per unmapping
     for (const item of items) {
       logger.info('SyncedItemsService#deleteSyncedItems :: Deleting mapping', item)
 
@@ -253,7 +265,7 @@ class SyncedItemsService extends AuthenticatedXeroService {
           'SyncedItemsService#deleteSyncedItem :: Attempted to delete non existant itemId for ',
           item,
         )
-        return
+        continue
       }
 
       await this.db

--- a/src/features/items-sync/types.ts
+++ b/src/features/items-sync/types.ts
@@ -1,10 +1,9 @@
 import type { Item } from 'xero-node'
-import type { CopilotPrice, CopilotProduct } from '@/lib/copilot/types'
+import type { CopilotProduct } from '@/lib/copilot/types'
 
 export type ProductMapping = {
-  price: CopilotPrice
   product: CopilotProduct
-  item?: (Pick<Item, 'itemID' | 'code' | 'name'> & { amount: number }) | null
+  item?: Pick<Item, 'itemID' | 'code' | 'name'> | null
 }
 
 export type Mappable = { productId: string; itemId: string | null }

--- a/src/features/items-sync/types.ts
+++ b/src/features/items-sync/types.ts
@@ -7,4 +7,4 @@ export type ProductMapping = {
   item?: (Pick<Item, 'itemID' | 'code' | 'name'> & { amount: number }) | null
 }
 
-export type Mappable = { productId: string; priceId: string; itemId: string | null }
+export type Mappable = { productId: string; itemId: string | null }

--- a/src/features/settings/actions/syncedItems.ts
+++ b/src/features/settings/actions/syncedItems.ts
@@ -20,7 +20,6 @@ export const updateSyncedItemsAction = async (token: string, productMappings: Pr
   return await productMappingsService.updateMappedItems(
     productMappings.map((mapping) => ({
       productId: mapping.product.id,
-      priceId: mapping.price.id,
       itemId: mapping.item?.itemID || null,
     })),
   )

--- a/src/features/settings/components/ProductMapping/ProductMappingTable.tsx
+++ b/src/features/settings/components/ProductMapping/ProductMappingTable.tsx
@@ -36,7 +36,7 @@ export const ProductMappingTable = ({ items }: ProductMappingTableProps) => {
           {items.length ? (
             items.map((item) => (
               <ProductMappingTableRow
-                key={item.price.id}
+                key={item.product.id}
                 item={item}
                 openDropdownId={openDropdownId}
                 setOpenDropdownId={setOpenDropdownId}

--- a/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
+++ b/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
@@ -72,7 +72,7 @@ export const ProductMappingTableRow = ({
 
   const excludeItemFromMapping = () => {
     const newProductMappings = productMappings.map((m) => {
-      if (m.price.id === item.price.id) {
+      if (m.product.id === item.product.id) {
         return { ...m, item: null }
       }
       return m
@@ -82,12 +82,12 @@ export const ProductMappingTableRow = ({
   }
 
   const handleSelectMapping = (newItem: ClientXeroItem) => {
-    const { itemID, name, code, amount } = newItem
+    const { itemID, name, code } = newItem
     const newProductMappings = productMappings.map((mapping) => {
-      if (mapping.price.id === item.price.id) {
+      if (mapping.product.id === item.product.id) {
         return {
           ...mapping,
-          item: { itemID, name, code, amount },
+          item: { itemID, name, code },
         }
       }
       return mapping
@@ -99,14 +99,11 @@ export const ProductMappingTableRow = ({
   const renderCurrency = (amount: number) => formatCurrencyForRegion(amount, countryCode)
 
   return (
-    <tr key={item.price.id} className="transition-colors">
+    <tr key={item.product.id} className="transition-colors">
       {/* Assembly Products Column */}
-      <td className="py-2 pr-3 pl-4" id={`price-id-${item.price.id}`}>
+      <td className="py-2 pr-3 pl-4" id={`product-id-${item.product.id}`}>
         <div className="break-all text-sm text-text-primary leading-5 lg:break-normal">
           {item.product.name}
-        </div>
-        <div className="text-body-xs text-text-secondary leading-5">
-          {renderCurrency(item.price.amount / 100)}
         </div>
       </td>
 
@@ -124,18 +121,15 @@ export const ProductMappingTableRow = ({
         <button
           type="button"
           onClick={() =>
-            setOpenDropdownId((prev) => (prev === item.price.id ? null : item.price.id))
+            setOpenDropdownId((prev) => (prev === item.product.id ? null : item.product.id))
           }
           className="mapping-btn grid h-full w-full grid-cols-6 py-2 pr-3 pl-4 transition-colors md:grid-cols-14"
         >
           <div className="col-span-5 text-left md:col-span-13">
             {xeroItem ? (
-              <div className="text-left">
+              <div className="py-2.5 text-left">
                 <div className="break-all text-sm text-text-primary leading-5 lg:break-normal">
                   {xeroItem.name}
-                </div>
-                <div className="text-body-xs text-text-secondary leading-5">
-                  {renderCurrency(xeroItem.amount)}
                 </div>
               </div>
             ) : (
@@ -150,7 +144,7 @@ export const ProductMappingTableRow = ({
         </button>
 
         {/* Dropdown */}
-        {item.price.id === openDropdownId && (
+        {item.product.id === openDropdownId && (
           <div
             ref={dropdownRef}
             className="items-dropdown !shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-[-1px] left-[-145px] z-100 mt-[-4px] rounded-sm border border-dropdown-border bg-white md:left-[-1px] md:min-w-[320px]"

--- a/src/features/settings/lib/ProductMappings.service.ts
+++ b/src/features/settings/lib/ProductMappings.service.ts
@@ -43,7 +43,7 @@ class ProductMappingsService extends AuthenticatedXeroService {
     // One row per product now that synced items map at the product level
     const mappings = Object.values(copilotProducts).map((product) => {
       const mapping = mappingRecords[product.id]
-      const item = mapping && xeroItems[mapping.itemId || '']
+      const item = mapping?.itemId && xeroItems[mapping.itemId]
       return {
         product,
         item: item

--- a/src/features/settings/lib/ProductMappings.service.ts
+++ b/src/features/settings/lib/ProductMappings.service.ts
@@ -33,36 +33,28 @@ class ProductMappingsService extends AuthenticatedXeroService {
     )
 
     const syncedItemsService = new SyncedItemsService(this.user, this.connection)
-    const mappingRecords = await syncedItemsService.getSyncedItemsMapByPriceIds('all')
+    const mappingRecords = await syncedItemsService.getSyncedItemsMapByProductIds('all')
 
-    const [xeroItems, copilotProducts, copilotPrices] = await Promise.all([
+    const [xeroItems, copilotProducts] = await Promise.all([
       this.xero.getItemsMap(this.connection.tenantId),
       this.copilot.getProductsMapById('all'),
-      this.copilot.getPricesMapById('all'),
     ])
 
-    const mappings = Object.values(copilotPrices)
-      // Sort by decreasing createdAt date
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-      // Map each to distinct price, product & item objs
-      .map((price) => {
-        const mapping = mappingRecords[price.id]
-        const item = mapping && xeroItems[mapping.itemId || '']
-        return {
-          price,
-          product: copilotProducts[price.productId],
-          item: item
-            ? {
-                itemID: item.itemID,
-                code: item.code,
-                name: item.name,
-                amount: item.salesDetails?.unitPrice || 0,
-              }
-            : null,
-        }
-      })
-      // Because the list endpoint could contain data for deleted products with hanging prices as well, remove them!
-      .filter((obj) => obj.product)
+    // One row per product now that synced items map at the product level
+    const mappings = Object.values(copilotProducts).map((product) => {
+      const mapping = mappingRecords[product.id]
+      const item = mapping && xeroItems[mapping.itemId || '']
+      return {
+        product,
+        item: item
+          ? {
+              itemID: item.itemID,
+              code: item.code,
+              name: item.name,
+            }
+          : null,
+      }
+    })
 
     return mappings
   }
@@ -73,7 +65,7 @@ class ProductMappingsService extends AuthenticatedXeroService {
       productMappings,
     )
 
-    // Create a map with priceId as key and SyncedItem as value
+    // Create a map with productId as key and SyncedItem as value
     const dbMappings = (
       await this.db
         .select()
@@ -85,7 +77,7 @@ class ProductMappingsService extends AuthenticatedXeroService {
           ),
         )
     ).reduce<Record<string, SyncedItem>>((acc, mapping) => {
-      acc[mapping.priceId] = mapping
+      acc[mapping.productId] = mapping
       return acc
     }, {})
 
@@ -93,7 +85,7 @@ class ProductMappingsService extends AuthenticatedXeroService {
       deletedMappings: Mappable[] = []
 
     for (const mapping of productMappings) {
-      const existingMapping = dbMappings[mapping.priceId]
+      const existingMapping = dbMappings[mapping.productId]
 
       // CASE I: Mapping exists or doesn't exist and is unchanged
       if (

--- a/src/features/webhook/lib/webhook.service.ts
+++ b/src/features/webhook/lib/webhook.service.ts
@@ -7,7 +7,7 @@ import {
   InvoiceCreatedEventSchema,
   InvoiceModifiedEventSchema,
   PaymentSucceededEventSchema,
-  PriceCreatedEventSchema,
+  ProductCreatedEventSchema,
   ProductUpdatedEventSchema,
   ValidWebhookEvent,
   type WebhookEvent,
@@ -54,7 +54,7 @@ class WebhookService extends AuthenticatedXeroService {
         [ValidWebhookEvent.InvoiceVoided]: this.handleInvoiceVoided,
         [ValidWebhookEvent.InvoiceDeleted]: this.handleInvoiceDeleted,
         [ValidWebhookEvent.ProductUpdated]: this.handleProductUpdated,
-        [ValidWebhookEvent.PriceCreated]: this.handlePriceCreated,
+        [ValidWebhookEvent.ProductCreated]: this.handleProductCreated,
         [ValidWebhookEvent.PaymentSucceeded]: this.handlePaymentSucceeded,
       }
 
@@ -151,7 +151,7 @@ class WebhookService extends AuthenticatedXeroService {
     const isSyncAutomaticallyEnabled = await this.checkAutomaticProductSyncEnabled()
     if (!isSyncAutomaticallyEnabled) {
       throw new APIError(
-        'Sync Products Automatically is disabled, cannot create synced item for new price',
+        'Sync Products Automatically is disabled, cannot update synced item for product',
         status.OK,
       )
     }
@@ -170,21 +170,28 @@ class WebhookService extends AuthenticatedXeroService {
     return { items }
   }
 
-  private handlePriceCreated = async (eventData: unknown) => {
-    logger.info('WebhookService#handleInvoiceCreated :: Handling price created')
+  private handleProductCreated = async (eventData: unknown) => {
+    logger.info('WebhookService#handleProductCreated :: Handling product created')
 
     const isSyncAutomaticallyEnabled = await this.checkAutomaticProductSyncEnabled()
     if (!isSyncAutomaticallyEnabled) {
       throw new APIError(
-        'Sync Products Automatically is disabled, cannot create synced item for new price',
+        'Sync Products Automatically is disabled, cannot create synced item for new product',
         status.OK,
       )
     }
 
-    const data = PriceCreatedEventSchema.parse(eventData)
+    const data = ProductCreatedEventSchema.parse(eventData)
     const syncedItemsService = new SyncedItemsService(this.user, this.connection)
-    const [newPrice] = await syncedItemsService.createSyncedItemsForPrices([data])
-    return newPrice
+    const [newItem] = await syncedItemsService.createSyncedItemsForProducts([data])
+    if (!newItem) {
+      logger.info(
+        'WebhookService#handleProductCreated :: Product already mapped, nothing to do',
+        data.id,
+      )
+      return
+    }
+    return newItem
   }
 
   private handlePaymentSucceeded = async (eventData: unknown) => {


### PR DESCRIPTION
## Summary

Migrates `synced_items` from one Xero Item per **price** to one per **product**, and updates all downstream code to match. Part of the [OUT-3788](https://linear.app/assemblycom/issue/OUT-3788) simplified-product-mapping epic.

Commits, by scope:

1. **Schema + data migration** (`09a8b24`) — drop the `price_id` column, replace the `(portal_id, product_id, price_id)` unique index with `(portal_id, tenant_id, product_id)`, and dedupe existing rows (earliest `createdAt` wins). *(OUT-3868)*
2. **Sync/service layer** (`433356a`) — move services to product-level: `Mappable` drops `priceId`; `getSyncedItemsMapByProductIds`, `getProductIdToXeroItem`, and `getCopilotProductAndXeroItem` replace their price-keyed equivalents; invoice line items resolve by `productId`. *(OUT-3869)*
3. **Mapping UI + API** (`c633347`) — one row per product: `ProductMapping` becomes `{ product, item }`, `getProductMappings` iterates products, the action/service operate on `{ productId, itemId }`, and the table drops the per-price/amount lines. *(OUT-3870)*

## Verification

- `pnpm typecheck` ✅
- `pnpm lint` ✅
- Pre-push build ✅

## Deferred follow-ups (tracked on [OUT-3869](https://linear.app/assemblycom/issue/OUT-3869))

These are webhook/sync-scope and intentionally **not** in this PR:

- 🔴 `price.created` → `createSyncedItemsForPrices` has no "already synced?" guard, so a second price for an already-synced product would create a duplicate Xero Item and hit the new unique constraint (caught → `failed_syncs` → retried forever). Needs an `onConflictDoNothing`/existence guard.
- 🟡 `addSyncedItems`/`deleteSyncedItems` use `return` instead of `continue` in the missing-`itemId` guard, aborting the whole batch.

## Testing Criteria

https://www.loom.com/share/0d075d8b0ee9431ca9542c300306b169

🤖 Generated with [Claude Code](https://claude.com/claude-code)