### PR TITLE
OUT-3887: Xero account selection — settings UI dropdowns

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -9,6 +9,7 @@ import { defaultSettings } from '@settings/constants/defaults'
 import { SettingsContextProvider } from '@settings/context/SettingsContext'
 import ProductMappingsService from '@settings/lib/ProductMappings.service'
 import SettingsService from '@settings/lib/Settings.service'
+import XeroAccountsService from '@settings/lib/XeroAccounts.service'
 import { SyncLogsService } from '@sync-logs/lib/SyncLogs.service'
 import type { CountryCode } from 'xero-node'
 import type { PageProps } from '@/app/(home)/types'
@@ -18,6 +19,7 @@ import { CopilotAPI } from '@/lib/copilot/CopilotAPI'
 import { serializeClientUser } from '@/lib/copilot/models/ClientUser.model'
 import User from '@/lib/copilot/models/User.model'
 import logger from '@/lib/logger'
+import type { ClientXeroAccounts } from '@/lib/xero/accounts'
 import { isSupportedCountry } from '@/lib/xero/region'
 import type { ClientXeroItem } from '@/lib/xero/types'
 import XeroAPI from '@/lib/xero/XeroAPI'
@@ -112,6 +114,20 @@ const getXeroItems = async (user: User, connection: XeroConnection): Promise<Cli
   return await productMappingsService.getClientXeroItems()
 }
 
+const getXeroAccounts = async (
+  user: User,
+  connection: XeroConnection,
+): Promise<ClientXeroAccounts> => {
+  if (!connection.tenantId || !connection.status)
+    return { income: [], bank: [], expense: [], archivedAccountCodes: [] }
+
+  const xeroAccountsService = new XeroAccountsService(
+    user,
+    connection as XeroConnectionWithTokenSet,
+  )
+  return await xeroAccountsService.getClientXeroAccounts()
+}
+
 const getLastSyncedAt = async (user: User, connection: XeroConnection): Promise<Date | null> => {
   if (!connection.tenantId || !connection.tokenSet) return null
 
@@ -146,28 +162,35 @@ const Home = async ({ searchParams }: PageProps) => {
     xeroAuthFailed = true
   }
 
-  const [settings, productMappings, xeroItems, lastSyncedAt, countryCode] = await Promise.all([
-    getSettings(user, connection),
-    withXeroErrorHandler(
-      getProductMappings(user, connection),
-      [],
-      'Error fetching product mappings',
-      onAuthError,
-    ),
-    withXeroErrorHandler(
-      getXeroItems(user, connection),
-      [],
-      'Error fetching xero items',
-      onAuthError,
-    ),
-    getLastSyncedAt(user, connection),
-    withXeroErrorHandler(
-      getCountryCode(connection),
-      null,
-      'Error fetching organisation country code',
-      onAuthError,
-    ),
-  ])
+  const [settings, productMappings, xeroItems, xeroAccounts, lastSyncedAt, countryCode] =
+    await Promise.all([
+      getSettings(user, connection),
+      withXeroErrorHandler(
+        getProductMappings(user, connection),
+        [],
+        'Error fetching product mappings',
+        onAuthError,
+      ),
+      withXeroErrorHandler(
+        getXeroItems(user, connection),
+        [],
+        'Error fetching xero items',
+        onAuthError,
+      ),
+      withXeroErrorHandler(
+        getXeroAccounts(user, connection),
+        { income: [], bank: [], expense: [], archivedAccountCodes: [] },
+        'Error fetching xero accounts',
+        onAuthError,
+      ),
+      getLastSyncedAt(user, connection),
+      withXeroErrorHandler(
+        getCountryCode(connection),
+        null,
+        'Error fetching organisation country code',
+        onAuthError,
+      ),
+    ])
 
   // Persist the resolved country code and gate sync to supported regions (US, AU)
   if (countryCode && connection.tenantId) {
@@ -215,6 +238,7 @@ const Home = async ({ searchParams }: PageProps) => {
         {...settings}
         productMappings={productMappings}
         xeroItems={xeroItems}
+        xeroAccounts={xeroAccounts}
       >
         <main className="min-h-[100vh] px-8 pt-6 pb-[54px] sm:px-[100px] lg:px-[220px]">
           <RealtimeXeroConnections user={clientUser} />

--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -118,7 +118,7 @@ const getXeroAccounts = async (
   user: User,
   connection: XeroConnection,
 ): Promise<ClientXeroAccounts> => {
-  if (!connection.tenantId || !connection.status)
+  if (!connection.tenantId || !connection.status || !connection.tokenSet)
     return { income: [], bank: [], expense: [], archivedAccountCodes: [] }
 
   const xeroAccountsService = new XeroAccountsService(
@@ -144,19 +144,7 @@ const getCountryCode = async (connection: XeroConnection): Promise<CountryCode |
   return countryCode || null
 }
 
-const Home = async ({ searchParams }: PageProps) => {
-  const sp = await searchParams
-  const user = await User.authenticate(sp.token)
-
-  const authService = new AuthService(user)
-
-  const copilot = new CopilotAPI(user.token)
-  const [rawConnection, workspace] = await Promise.all([
-    authService.authorizeXeroForCopilotWorkspace(true),
-    copilot.getWorkspace(),
-  ])
-  const connection = await ensureValidConnection(user, rawConnection)
-
+const getPageData = async (user: User, connection: XeroConnection) => {
   let xeroAuthFailed = false
   const onAuthError = () => {
     xeroAuthFailed = true
@@ -191,6 +179,40 @@ const Home = async ({ searchParams }: PageProps) => {
         onAuthError,
       ),
     ])
+
+  return {
+    settings,
+    productMappings,
+    xeroItems,
+    xeroAccounts,
+    lastSyncedAt,
+    countryCode,
+    xeroAuthFailed,
+  }
+}
+
+const Home = async ({ searchParams }: PageProps) => {
+  const sp = await searchParams
+  const user = await User.authenticate(sp.token)
+
+  const authService = new AuthService(user)
+
+  const copilot = new CopilotAPI(user.token)
+  const [rawConnection, workspace] = await Promise.all([
+    authService.authorizeXeroForCopilotWorkspace(true),
+    copilot.getWorkspace(),
+  ])
+  const connection = await ensureValidConnection(user, rawConnection)
+
+  const {
+    settings,
+    productMappings,
+    xeroItems,
+    xeroAccounts,
+    lastSyncedAt,
+    countryCode,
+    xeroAuthFailed,
+  } = await getPageData(user, connection)
 
   // Persist the resolved country code and gate sync to supported regions (US, AU)
   if (countryCode && connection.tenantId) {

--- a/src/components/ui/SearchableSelectMenu.tsx
+++ b/src/components/ui/SearchableSelectMenu.tsx
@@ -1,5 +1,5 @@
 import { useDropdown } from '@settings/hooks/useDropdown'
-import { type ReactNode, useEffect, useRef, useState } from 'react'
+import { type ReactNode, useCallback, useEffect, useRef, useState } from 'react'
 
 // Focus index for the optional action row. -1 = none, 0.. = options.
 const ACTION_INDEX = -2
@@ -10,7 +10,8 @@ interface SearchableSelectMenuProps<T> {
   searchPlaceholder?: string
   options: T[]
   getOptionKey: (option: T) => string
-  getSearchText: (option: T) => string
+  // Each value is matched independently against the query (OR semantics).
+  getSearchValues: (option: T) => string[]
   renderOption: (option: T) => ReactNode
   onSelect: (option: T) => void
   emptyText: string
@@ -26,19 +27,26 @@ export const SearchableSelectMenu = <T,>({
   searchPlaceholder = 'Search',
   options,
   getOptionKey,
-  getSearchText,
+  getSearchValues,
   renderOption,
   onSelect,
   emptyText,
   action,
 }: SearchableSelectMenuProps<T>) => {
-  const { dropdownRef } = useDropdown({ setOpenDropdownId: onClose })
+  // Keep a stable close reference so useDropdown doesn't re-bind its listener each render.
+  const onCloseRef = useRef(onClose)
+  onCloseRef.current = onClose
+  const close = useCallback(() => onCloseRef.current(), [])
+
+  const { dropdownRef } = useDropdown({ setOpenDropdownId: close })
   const [searchQuery, setSearchQuery] = useState('')
   const [focusedIndex, setFocusedIndex] = useState(-1)
   const listRef = useRef<HTMLDivElement>(null)
 
   const query = searchQuery.toLowerCase()
-  const filtered = options.filter((option) => getSearchText(option).toLowerCase().includes(query))
+  const filtered = options.filter((option) =>
+    getSearchValues(option).some((value) => value.toLowerCase().includes(query)),
+  )
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reset focus when query changes
   useEffect(() => {
@@ -54,12 +62,12 @@ export const SearchableSelectMenu = <T,>({
 
   const selectOption = (option: T) => {
     onSelect(option)
-    onClose()
+    close()
   }
 
   const selectAction = () => {
     action?.onSelect()
-    onClose()
+    close()
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -90,7 +98,7 @@ export const SearchableSelectMenu = <T,>({
       else if (filtered[focusedIndex]) selectOption(filtered[focusedIndex])
     } else if (e.key === 'Escape') {
       e.preventDefault()
-      onClose()
+      close()
     }
   }
 

--- a/src/components/ui/SearchableSelectMenu.tsx
+++ b/src/components/ui/SearchableSelectMenu.tsx
@@ -1,0 +1,147 @@
+import { useDropdown } from '@settings/hooks/useDropdown'
+import { type ReactNode, useEffect, useRef, useState } from 'react'
+
+// Focus index for the optional action row. -1 = none, 0.. = options.
+const ACTION_INDEX = -2
+
+interface SearchableSelectMenuProps<T> {
+  onClose: () => void
+  className?: string
+  searchPlaceholder?: string
+  options: T[]
+  getOptionKey: (option: T) => string
+  getSearchText: (option: T) => string
+  renderOption: (option: T) => ReactNode
+  onSelect: (option: T) => void
+  emptyText: string
+  action?: {
+    render: () => ReactNode
+    onSelect: () => void
+  }
+}
+
+export const SearchableSelectMenu = <T,>({
+  onClose,
+  className,
+  searchPlaceholder = 'Search',
+  options,
+  getOptionKey,
+  getSearchText,
+  renderOption,
+  onSelect,
+  emptyText,
+  action,
+}: SearchableSelectMenuProps<T>) => {
+  const { dropdownRef } = useDropdown({ setOpenDropdownId: onClose })
+  const [searchQuery, setSearchQuery] = useState('')
+  const [focusedIndex, setFocusedIndex] = useState(-1)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const query = searchQuery.toLowerCase()
+  const filtered = options.filter((option) => getSearchText(option).toLowerCase().includes(query))
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset focus when query changes
+  useEffect(() => {
+    setFocusedIndex(-1)
+  }, [searchQuery])
+
+  useEffect(() => {
+    // Only option rows live in the scrollable list.
+    if (focusedIndex < 0 || !listRef.current) return
+    const focusedElement = listRef.current.children[focusedIndex] as HTMLElement | undefined
+    focusedElement?.scrollIntoView({ block: 'nearest' })
+  }, [focusedIndex])
+
+  const selectOption = (option: T) => {
+    onSelect(option)
+    onClose()
+  }
+
+  const selectAction = () => {
+    action?.onSelect()
+    onClose()
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    const lastIndex = filtered.length - 1
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setFocusedIndex((prev) => {
+        // From the top, hit the action row first when present.
+        if (prev === -1) {
+          if (action) return ACTION_INDEX
+          return lastIndex >= 0 ? 0 : -1
+        }
+        if (prev === ACTION_INDEX) return lastIndex >= 0 ? 0 : ACTION_INDEX
+        return Math.min(prev + 1, lastIndex)
+      })
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setFocusedIndex((prev) => {
+        if (prev === -1) return lastIndex >= 0 ? lastIndex : action ? ACTION_INDEX : -1
+        if (prev === 0) return action ? ACTION_INDEX : 0
+        // Action row is the top; no wrap.
+        if (prev === ACTION_INDEX) return ACTION_INDEX
+        return Math.max(prev - 1, 0)
+      })
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (focusedIndex === ACTION_INDEX) selectAction()
+      else if (filtered[focusedIndex]) selectOption(filtered[focusedIndex])
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      onClose()
+    }
+  }
+
+  return (
+    <div ref={dropdownRef} className={className}>
+      <div className="px-3 py-2">
+        <input
+          type="text"
+          placeholder={searchPlaceholder}
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          // biome-ignore lint/a11y/noAutofocus: focus search on open
+          autoFocus
+          className="w-full text-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
+        />
+      </div>
+
+      {action && (
+        <div
+          className={`border-card-divider border-t-1 transition-colors hover:bg-gray-100 ${
+            focusedIndex === ACTION_INDEX ? 'bg-gray-100' : ''
+          }`}
+        >
+          <button
+            type="button"
+            className="h-full w-full cursor-pointer px-3 py-2 text-left text-sm text-text-primary"
+            onClick={selectAction}
+          >
+            {action.render()}
+          </button>
+        </div>
+      )}
+
+      <div className="max-h-56 overflow-y-auto border-card-divider border-t-1" ref={listRef}>
+        {filtered.map((option, index) => (
+          <button
+            type="button"
+            key={getOptionKey(option)}
+            onClick={() => selectOption(option)}
+            className={`flex w-full cursor-pointer items-center justify-between px-3 py-1.5 text-left text-sm transition-colors hover:bg-gray-100 ${
+              index === focusedIndex ? 'bg-gray-100' : ''
+            }`}
+          >
+            {renderOption(option)}
+          </button>
+        ))}
+        {filtered.length === 0 && (
+          <div className="px-3 py-2 text-gray-500 text-sm">{emptyText}</div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/settings/components/AccountMapping/AccountSelect.tsx
+++ b/src/features/settings/components/AccountMapping/AccountSelect.tsx
@@ -1,8 +1,7 @@
 import type { SettingsContextType } from '@settings/context/SettingsContext'
-import { useDropdown } from '@settings/hooks/useDropdown'
 import { useSettingsContext } from '@settings/hooks/useSettings'
 import { Icon } from 'copilot-design-system'
-import { useEffect, useRef, useState } from 'react'
+import { SearchableSelectMenu } from '@/components/ui/SearchableSelectMenu'
 import type { ClientXeroAccount } from '@/lib/xero/accounts'
 
 export type AccountFieldKey = 'incomeAccountId' | 'bankAccountId' | 'expenseAccountId'
@@ -53,9 +52,6 @@ const TRIGGER_TONE_CLASS: Record<TriggerTone, string> = {
   muted: 'text-gray-500',
 }
 
-// Focus index for the default option. -1 = none, 0.. = accounts.
-const DEFAULT_OPTION_INDEX = -2
-
 export const AccountSelect = ({
   label,
   description,
@@ -68,7 +64,6 @@ export const AccountSelect = ({
   openDropdownId,
   setOpenDropdownId,
 }: AccountSelectProps) => {
-  const { dropdownRef } = useDropdown({ setOpenDropdownId })
   const { updateSettings } = useSettingsContext()
 
   // Only active accounts are listed, so a missing/archived saved id won't match.
@@ -79,12 +74,8 @@ export const AccountSelect = ({
   const defaultActiveAccount = defaultCode
     ? accounts.find((account) => account.code === defaultCode)
     : undefined
-  const defaultUsable = defaultCode !== null && !defaultIsArchived
+  const defaultUsable = !!defaultCode && !defaultIsArchived
   const defaultDisplay = formatDefaultDisplay(defaultActiveAccount, defaultName, defaultCode)
-
-  const [searchQuery, setSearchQuery] = useState('')
-  const [focusedIndex, setFocusedIndex] = useState(-1)
-  const listRef = useRef<HTMLDivElement>(null)
 
   const isOpen = openDropdownId === field
 
@@ -95,71 +86,8 @@ export const AccountSelect = ({
     if (requiresPayments && account.enablePaymentsToAccount !== true) return false
     // Shown in the header row; don't list it twice.
     if (defaultUsable && account.accountId === defaultActiveAccount?.accountId) return false
-    const query = searchQuery.toLowerCase()
-    return (
-      (account.name ?? '').toLowerCase().includes(query) ||
-      (account.code ?? '').toLowerCase().includes(query)
-    )
+    return true
   })
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: reset focus when query changes
-  useEffect(() => {
-    setFocusedIndex(-1)
-  }, [searchQuery])
-
-  useEffect(() => {
-    if (!isOpen) setSearchQuery('')
-  }, [isOpen])
-
-  useEffect(() => {
-    // Only account rows live in the scrollable list.
-    if (focusedIndex < 0 || !listRef.current) return
-    const focusedElement = listRef.current.children[focusedIndex] as HTMLElement | undefined
-    focusedElement?.scrollIntoView({ block: 'nearest' })
-  }, [focusedIndex])
-
-  const selectAccount = (account: ClientXeroAccount) => {
-    updateSettings({ [field]: account.accountId } as Partial<SettingsContextType>)
-    setOpenDropdownId(null)
-  }
-
-  // Clear to fall back to the region default.
-  const selectDefault = () => {
-    updateSettings({ [field]: null } as Partial<SettingsContextType>)
-    setOpenDropdownId(null)
-  }
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    const lastIndex = filteredAccounts.length - 1
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      setFocusedIndex((prev) => {
-        // From the top, hit the default option first when available.
-        if (prev === -1) {
-          if (defaultUsable) return DEFAULT_OPTION_INDEX
-          return lastIndex >= 0 ? 0 : -1
-        }
-        if (prev === DEFAULT_OPTION_INDEX) return lastIndex >= 0 ? 0 : DEFAULT_OPTION_INDEX
-        return Math.min(prev + 1, lastIndex)
-      })
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      setFocusedIndex((prev) => {
-        if (prev === -1) return lastIndex >= 0 ? lastIndex : DEFAULT_OPTION_INDEX
-        if (prev === 0) return defaultUsable ? DEFAULT_OPTION_INDEX : 0
-        // Default option is the top; no wrap.
-        if (prev === DEFAULT_OPTION_INDEX) return DEFAULT_OPTION_INDEX
-        return Math.max(prev - 1, 0)
-      })
-    } else if (e.key === 'Enter') {
-      e.preventDefault()
-      if (focusedIndex === DEFAULT_OPTION_INDEX) selectDefault()
-      else if (filteredAccounts[focusedIndex]) selectAccount(filteredAccounts[focusedIndex])
-    } else if (e.key === 'Escape') {
-      e.preventDefault()
-      setOpenDropdownId(null)
-    }
-  }
 
   // Trigger label + tone, in priority order.
   let triggerLabel: string
@@ -201,64 +129,38 @@ export const AccountSelect = ({
         </button>
 
         {isOpen && (
-          <div
-            ref={dropdownRef}
-            className="account-dropdown !shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-0 left-0 z-100 mt-[-2px] rounded-sm border border-dropdown-border bg-white"
-          >
-            <div className="px-3 py-2">
-              <input
-                type="text"
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={handleKeyDown}
-                // biome-ignore lint/a11y/noAutofocus: focus search on open, matches product mapping
-                autoFocus
-                className="w-full text-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
-              />
-            </div>
-
-            {defaultUsable && (
-              <div
-                className={`border-card-divider border-t-1 transition-colors hover:bg-gray-100 ${
-                  focusedIndex === DEFAULT_OPTION_INDEX ? 'bg-gray-100' : ''
-                }`}
-              >
-                <button
-                  type="button"
-                  className="h-full w-full cursor-pointer px-3 py-2 text-left text-sm text-text-primary"
-                  onClick={selectDefault}
-                >
-                  {`Use default account (${defaultDisplay})`}
-                </button>
-              </div>
-            )}
-
-            <div className="max-h-56 overflow-y-auto border-card-divider border-t-1" ref={listRef}>
-              {filteredAccounts.map((account, index) => (
-                <button
-                  type="button"
-                  key={account.accountId}
-                  onClick={() => selectAccount(account)}
-                  className={`account-option-btn flex w-full cursor-pointer items-center justify-between px-3 py-1.5 text-left text-sm transition-colors hover:bg-gray-100 ${
-                    index === focusedIndex ? 'bg-gray-100' : ''
-                  }`}
-                >
-                  <span className="line-clamp-1 break-all text-text-primary lg:break-normal">
-                    {account.name ?? 'Unnamed account'}
+          <SearchableSelectMenu
+            onClose={() => setOpenDropdownId(null)}
+            className="!shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-0 left-0 z-100 mt-[-2px] rounded-sm border border-dropdown-border bg-white"
+            options={filteredAccounts}
+            getOptionKey={(account) => account.accountId}
+            getSearchText={(account) => `${account.name ?? ''} ${account.code ?? ''}`}
+            onSelect={(account) =>
+              updateSettings({ [field]: account.accountId } as Partial<SettingsContextType>)
+            }
+            emptyText="No accounts found"
+            action={
+              defaultUsable
+                ? {
+                    render: () => `Use default account (${defaultDisplay})`,
+                    onSelect: () =>
+                      updateSettings({ [field]: null } as Partial<SettingsContextType>),
+                  }
+                : undefined
+            }
+            renderOption={(account) => (
+              <>
+                <span className="line-clamp-1 break-all text-text-primary lg:break-normal">
+                  {account.name ?? 'Unnamed account'}
+                </span>
+                {account.code && (
+                  <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
+                    {account.code}
                   </span>
-                  {account.code && (
-                    <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
-                      {account.code}
-                    </span>
-                  )}
-                </button>
-              ))}
-              {filteredAccounts.length === 0 && (
-                <div className="px-3 py-2 text-gray-500 text-sm">No accounts found</div>
-              )}
-            </div>
-          </div>
+                )}
+              </>
+            )}
+          />
         )}
       </div>
     </div>

--- a/src/features/settings/components/AccountMapping/AccountSelect.tsx
+++ b/src/features/settings/components/AccountMapping/AccountSelect.tsx
@@ -52,6 +52,23 @@ const TRIGGER_TONE_CLASS: Record<TriggerTone, string> = {
   muted: 'text-gray-500',
 }
 
+// Trigger label + tone, in priority order.
+const getTrigger = (
+  selectedAccount: ClientXeroAccount | undefined,
+  hasStaleSelection: boolean,
+  defaultIsArchived: boolean,
+  defaultUsable: boolean,
+  defaultDisplay: string,
+  fieldLabel: string,
+): { label: string; tone: TriggerTone } => {
+  if (selectedAccount) return { label: accountLabel(selectedAccount), tone: 'primary' }
+  if (hasStaleSelection) return { label: 'Selected account unavailable', tone: 'danger' }
+  if (defaultIsArchived)
+    return { label: 'Default account unavailable — please select an account', tone: 'danger' }
+  if (defaultUsable) return { label: `Use default account (${defaultDisplay})`, tone: 'muted' }
+  return { label: `Please select ${fieldLabel.toLowerCase()}`, tone: 'muted' }
+}
+
 export const AccountSelect = ({
   label,
   description,
@@ -89,25 +106,14 @@ export const AccountSelect = ({
     return true
   })
 
-  // Trigger label + tone, in priority order.
-  let triggerLabel: string
-  let triggerTone: TriggerTone
-  if (selectedAccount) {
-    triggerLabel = accountLabel(selectedAccount)
-    triggerTone = 'primary'
-  } else if (hasStaleSelection) {
-    triggerLabel = 'Selected account unavailable'
-    triggerTone = 'danger'
-  } else if (defaultIsArchived) {
-    triggerLabel = 'Default account unavailable — please select an account'
-    triggerTone = 'danger'
-  } else if (defaultUsable) {
-    triggerLabel = `Use default account (${defaultDisplay})`
-    triggerTone = 'muted'
-  } else {
-    triggerLabel = `Please select ${label.toLowerCase()}`
-    triggerTone = 'muted'
-  }
+  const { label: triggerLabel, tone: triggerTone } = getTrigger(
+    selectedAccount,
+    hasStaleSelection,
+    defaultIsArchived,
+    defaultUsable,
+    defaultDisplay,
+    label,
+  )
 
   return (
     <div className="mb-6">

--- a/src/features/settings/components/AccountMapping/AccountSelect.tsx
+++ b/src/features/settings/components/AccountMapping/AccountSelect.tsx
@@ -53,6 +53,9 @@ const TRIGGER_TONE_CLASS: Record<TriggerTone, string> = {
   muted: 'text-gray-500',
 }
 
+// Focus index for the default option. -1 = none, 0.. = accounts.
+const DEFAULT_OPTION_INDEX = -2
+
 export const AccountSelect = ({
   label,
   description,
@@ -90,6 +93,8 @@ export const AccountSelect = ({
 
   const filteredAccounts = accounts.filter((account) => {
     if (requiresPayments && account.enablePaymentsToAccount !== true) return false
+    // Shown in the header row; don't list it twice.
+    if (defaultUsable && account.accountId === defaultActiveAccount?.accountId) return false
     const query = searchQuery.toLowerCase()
     return (
       (account.name ?? '').toLowerCase().includes(query) ||
@@ -107,35 +112,49 @@ export const AccountSelect = ({
   }, [isOpen])
 
   useEffect(() => {
-    if (listRef.current && filteredAccounts.length > 0) {
-      const focusedElement = listRef.current.children[focusedIndex] as HTMLElement
-      if (focusedElement) focusedElement.scrollIntoView({ block: 'nearest' })
-    }
-  }, [focusedIndex, filteredAccounts.length])
+    // Only account rows live in the scrollable list.
+    if (focusedIndex < 0 || !listRef.current) return
+    const focusedElement = listRef.current.children[focusedIndex] as HTMLElement | undefined
+    focusedElement?.scrollIntoView({ block: 'nearest' })
+  }, [focusedIndex])
 
   const selectAccount = (account: ClientXeroAccount) => {
-    // Picking the default account = use default: keep the field null.
-    const value = account.accountId === defaultActiveAccount?.accountId ? null : account.accountId
-    updateSettings({ [field]: value } as Partial<SettingsContextType>)
+    updateSettings({ [field]: account.accountId } as Partial<SettingsContextType>)
     setOpenDropdownId(null)
   }
 
   // Clear to fall back to the region default.
-  const useDefault = () => {
+  const selectDefault = () => {
     updateSettings({ [field]: null } as Partial<SettingsContextType>)
     setOpenDropdownId(null)
   }
 
   const handleKeyDown = (e: React.KeyboardEvent) => {
+    const lastIndex = filteredAccounts.length - 1
     if (e.key === 'ArrowDown') {
       e.preventDefault()
-      setFocusedIndex((prev) => (prev === -1 ? 0 : Math.min(prev + 1, filteredAccounts.length - 1)))
+      setFocusedIndex((prev) => {
+        // From the top, hit the default option first when available.
+        if (prev === -1) {
+          if (defaultUsable) return DEFAULT_OPTION_INDEX
+          return lastIndex >= 0 ? 0 : -1
+        }
+        if (prev === DEFAULT_OPTION_INDEX) return lastIndex >= 0 ? 0 : DEFAULT_OPTION_INDEX
+        return Math.min(prev + 1, lastIndex)
+      })
     } else if (e.key === 'ArrowUp') {
       e.preventDefault()
-      setFocusedIndex((prev) => (prev === -1 ? filteredAccounts.length - 1 : Math.max(prev - 1, 0)))
+      setFocusedIndex((prev) => {
+        if (prev === -1) return lastIndex >= 0 ? lastIndex : DEFAULT_OPTION_INDEX
+        if (prev === 0) return defaultUsable ? DEFAULT_OPTION_INDEX : 0
+        // Default option is the top; no wrap.
+        if (prev === DEFAULT_OPTION_INDEX) return DEFAULT_OPTION_INDEX
+        return Math.max(prev - 1, 0)
+      })
     } else if (e.key === 'Enter') {
       e.preventDefault()
-      if (filteredAccounts[focusedIndex]) selectAccount(filteredAccounts[focusedIndex])
+      if (focusedIndex === DEFAULT_OPTION_INDEX) selectDefault()
+      else if (filteredAccounts[focusedIndex]) selectAccount(filteredAccounts[focusedIndex])
     } else if (e.key === 'Escape') {
       e.preventDefault()
       setOpenDropdownId(null)
@@ -200,11 +219,15 @@ export const AccountSelect = ({
             </div>
 
             {defaultUsable && (
-              <div className="border-card-divider border-t-1 hover:bg-gray-100">
+              <div
+                className={`border-card-divider border-t-1 transition-colors hover:bg-gray-100 ${
+                  focusedIndex === DEFAULT_OPTION_INDEX ? 'bg-gray-100' : ''
+                }`}
+              >
                 <button
                   type="button"
                   className="h-full w-full cursor-pointer px-3 py-2 text-left text-sm text-text-primary"
-                  onClick={useDefault}
+                  onClick={selectDefault}
                 >
                   {`Use default account (${defaultDisplay})`}
                 </button>

--- a/src/features/settings/components/AccountMapping/AccountSelect.tsx
+++ b/src/features/settings/components/AccountMapping/AccountSelect.tsx
@@ -1,0 +1,243 @@
+import type { SettingsContextType } from '@settings/context/SettingsContext'
+import { useDropdown } from '@settings/hooks/useDropdown'
+import { useSettingsContext } from '@settings/hooks/useSettings'
+import { Icon } from 'copilot-design-system'
+import { useEffect, useRef, useState } from 'react'
+import type { ClientXeroAccount } from '@/lib/xero/accounts'
+
+export type AccountFieldKey = 'incomeAccountId' | 'bankAccountId' | 'expenseAccountId'
+
+interface AccountSelectProps {
+  label: string
+  description: string
+  field: AccountFieldKey
+  accounts: ClientXeroAccount[]
+  selectedAccountId: string | null
+  // Region default for this role, used when unset.
+  defaultCode: string | null
+  defaultName: string | null
+  // Default code is held by an archived account (can't be recreated).
+  defaultIsArchived: boolean
+  openDropdownId: string | null
+  setOpenDropdownId: React.Dispatch<React.SetStateAction<string | null>>
+}
+
+const accountLabel = (account: ClientXeroAccount): string =>
+  account.code
+    ? `${account.name ?? 'Unnamed account'} (${account.code})`
+    : (account.name ?? 'Unnamed account')
+
+// "name - code" form for the default affordance.
+const defaultAccountLabel = (account: ClientXeroAccount): string =>
+  account.code
+    ? `${account.name ?? 'Unnamed account'} - ${account.code}`
+    : (account.name ?? 'Unnamed account')
+
+// Default label: the live account, else the name/code we'd create.
+const formatDefaultDisplay = (
+  defaultActiveAccount: ClientXeroAccount | undefined,
+  defaultName: string | null,
+  defaultCode: string | null,
+): string => {
+  if (defaultActiveAccount) return defaultAccountLabel(defaultActiveAccount)
+  if (defaultName && defaultCode) return `${defaultName} - ${defaultCode}`
+  return defaultCode ?? ''
+}
+
+// Trigger tone → text colour.
+type TriggerTone = 'primary' | 'danger' | 'muted'
+
+const TRIGGER_TONE_CLASS: Record<TriggerTone, string> = {
+  primary: 'text-text-primary',
+  danger: 'text-red-600',
+  muted: 'text-gray-500',
+}
+
+export const AccountSelect = ({
+  label,
+  description,
+  field,
+  accounts,
+  selectedAccountId,
+  defaultCode,
+  defaultName,
+  defaultIsArchived,
+  openDropdownId,
+  setOpenDropdownId,
+}: AccountSelectProps) => {
+  const { dropdownRef } = useDropdown({ setOpenDropdownId })
+  const { updateSettings } = useSettingsContext()
+
+  // Only active accounts are listed, so a missing/archived saved id won't match.
+  const selectedAccount = accounts.find((account) => account.accountId === selectedAccountId)
+  const hasStaleSelection = !selectedAccount && selectedAccountId !== null
+
+  // The default is usable unless an archived account holds its code (can't be recreated).
+  const defaultActiveAccount = defaultCode
+    ? accounts.find((account) => account.code === defaultCode)
+    : undefined
+  const defaultUsable = defaultCode !== null && !defaultIsArchived
+  const defaultDisplay = formatDefaultDisplay(defaultActiveAccount, defaultName, defaultCode)
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [focusedIndex, setFocusedIndex] = useState(-1)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const isOpen = openDropdownId === field
+
+  // Only payment-enabled income/expense accounts are selectable; bank accounts lack the flag.
+  const requiresPayments = field !== 'bankAccountId'
+
+  const filteredAccounts = accounts.filter((account) => {
+    if (requiresPayments && account.enablePaymentsToAccount !== true) return false
+    const query = searchQuery.toLowerCase()
+    return (
+      (account.name ?? '').toLowerCase().includes(query) ||
+      (account.code ?? '').toLowerCase().includes(query)
+    )
+  })
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reset focus when query changes
+  useEffect(() => {
+    setFocusedIndex(-1)
+  }, [searchQuery])
+
+  useEffect(() => {
+    if (!isOpen) setSearchQuery('')
+  }, [isOpen])
+
+  useEffect(() => {
+    if (listRef.current && filteredAccounts.length > 0) {
+      const focusedElement = listRef.current.children[focusedIndex] as HTMLElement
+      if (focusedElement) focusedElement.scrollIntoView({ block: 'nearest' })
+    }
+  }, [focusedIndex, filteredAccounts.length])
+
+  const selectAccount = (account: ClientXeroAccount) => {
+    // Picking the default account = use default: keep the field null.
+    const value = account.accountId === defaultActiveAccount?.accountId ? null : account.accountId
+    updateSettings({ [field]: value } as Partial<SettingsContextType>)
+    setOpenDropdownId(null)
+  }
+
+  // Clear to fall back to the region default.
+  const useDefault = () => {
+    updateSettings({ [field]: null } as Partial<SettingsContextType>)
+    setOpenDropdownId(null)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault()
+      setFocusedIndex((prev) => (prev === -1 ? 0 : Math.min(prev + 1, filteredAccounts.length - 1)))
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault()
+      setFocusedIndex((prev) => (prev === -1 ? filteredAccounts.length - 1 : Math.max(prev - 1, 0)))
+    } else if (e.key === 'Enter') {
+      e.preventDefault()
+      if (filteredAccounts[focusedIndex]) selectAccount(filteredAccounts[focusedIndex])
+    } else if (e.key === 'Escape') {
+      e.preventDefault()
+      setOpenDropdownId(null)
+    }
+  }
+
+  // Trigger label + tone, in priority order.
+  let triggerLabel: string
+  let triggerTone: TriggerTone
+  if (selectedAccount) {
+    triggerLabel = accountLabel(selectedAccount)
+    triggerTone = 'primary'
+  } else if (hasStaleSelection) {
+    triggerLabel = 'Selected account unavailable'
+    triggerTone = 'danger'
+  } else if (defaultIsArchived) {
+    triggerLabel = 'Default account unavailable — please select an account'
+    triggerTone = 'danger'
+  } else if (defaultUsable) {
+    triggerLabel = `Use default account (${defaultDisplay})`
+    triggerTone = 'muted'
+  } else {
+    triggerLabel = `Please select ${label.toLowerCase()}`
+    triggerTone = 'muted'
+  }
+
+  return (
+    <div className="mb-6">
+      <div className="font-semibold text-sm text-text-primary leading-5">{label}</div>
+      <p className="mt-1 mb-2 text-gray-600 text-sm leading-5">{description}</p>
+
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setOpenDropdownId((prev) => (prev === field ? null : field))}
+          className="mapping-btn flex w-full items-center justify-between rounded-sm border border-dropdown-border bg-gray-100 px-3 py-2 transition-colors hover:bg-gray-150"
+        >
+          <span
+            className={`line-clamp-1 break-all text-left text-sm lg:break-normal ${TRIGGER_TONE_CLASS[triggerTone]}`}
+          >
+            {triggerLabel}
+          </span>
+          <Icon icon="ChevronDown" width={16} height={16} className="ms-2 text-gray-500" />
+        </button>
+
+        {isOpen && (
+          <div
+            ref={dropdownRef}
+            className="account-dropdown !shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-0 left-0 z-100 mt-[-2px] rounded-sm border border-dropdown-border bg-white"
+          >
+            <div className="px-3 py-2">
+              <input
+                type="text"
+                placeholder="Search"
+                value={searchQuery}
+                onChange={(e) => setSearchQuery(e.target.value)}
+                onKeyDown={handleKeyDown}
+                // biome-ignore lint/a11y/noAutofocus: focus search on open, matches product mapping
+                autoFocus
+                className="w-full text-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
+              />
+            </div>
+
+            {defaultUsable && (
+              <div className="border-card-divider border-t-1 hover:bg-gray-100">
+                <button
+                  type="button"
+                  className="h-full w-full cursor-pointer px-3 py-2 text-left text-sm text-text-primary"
+                  onClick={useDefault}
+                >
+                  {`Use default account (${defaultDisplay})`}
+                </button>
+              </div>
+            )}
+
+            <div className="max-h-56 overflow-y-auto border-card-divider border-t-1" ref={listRef}>
+              {filteredAccounts.map((account, index) => (
+                <button
+                  type="button"
+                  key={account.accountId}
+                  onClick={() => selectAccount(account)}
+                  className={`account-option-btn flex w-full cursor-pointer items-center justify-between px-3 py-1.5 text-left text-sm transition-colors hover:bg-gray-100 ${
+                    index === focusedIndex ? 'bg-gray-100' : ''
+                  }`}
+                >
+                  <span className="line-clamp-1 break-all text-text-primary lg:break-normal">
+                    {account.name ?? 'Unnamed account'}
+                  </span>
+                  {account.code && (
+                    <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
+                      {account.code}
+                    </span>
+                  )}
+                </button>
+              ))}
+              {filteredAccounts.length === 0 && (
+                <div className="px-3 py-2 text-gray-500 text-sm">No accounts found</div>
+              )}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/src/features/settings/components/AccountMapping/AccountSelect.tsx
+++ b/src/features/settings/components/AccountMapping/AccountSelect.tsx
@@ -134,7 +134,7 @@ export const AccountSelect = ({
             className="!shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-0 left-0 z-100 mt-[-2px] rounded-sm border border-dropdown-border bg-white"
             options={filteredAccounts}
             getOptionKey={(account) => account.accountId}
-            getSearchText={(account) => `${account.name ?? ''} ${account.code ?? ''}`}
+            getSearchValues={(account) => [account.name ?? '', account.code ?? '']}
             onSelect={(account) =>
               updateSettings({ [field]: account.accountId } as Partial<SettingsContextType>)
             }

--- a/src/features/settings/components/AccountMapping/index.tsx
+++ b/src/features/settings/components/AccountMapping/index.tsx
@@ -1,0 +1,83 @@
+'use client'
+
+import { useAuthContext } from '@auth/hooks/useAuth'
+import {
+  type AccountFieldKey,
+  AccountSelect,
+} from '@settings/components/AccountMapping/AccountSelect'
+import { useSettingsContext } from '@settings/hooks/useSettings'
+import { useState } from 'react'
+import type { ClientXeroAccount } from '@/lib/xero/accounts'
+import { isSupportedCountry, regionConfigFor } from '@/lib/xero/region'
+
+export const AccountMapping = () => {
+  const { xeroAccounts, incomeAccountId, bankAccountId, expenseAccountId } = useSettingsContext()
+  const { countryCode } = useAuthContext()
+  const [openDropdownId, setOpenDropdownId] = useState<string | null>(null)
+
+  // Region defaults used when a field is unset.
+  const regionConfig = isSupportedCountry(countryCode) ? regionConfigFor(countryCode) : null
+
+  // An archived default code can't be recreated, so force an explicit selection.
+  const isDefaultArchived = (defaultCode: string | null): boolean =>
+    defaultCode !== null && xeroAccounts.archivedAccountCodes.includes(defaultCode)
+
+  const rows: {
+    label: string
+    description: string
+    field: AccountFieldKey
+    accounts: ClientXeroAccount[]
+    selectedAccountId: string | null
+    defaultCode: string | null
+    defaultName: string | null
+  }[] = [
+    {
+      label: 'Income account',
+      description: 'Default income account assigned to services synced from Assembly to Xero.',
+      field: 'incomeAccountId',
+      accounts: xeroAccounts.income,
+      selectedAccountId: incomeAccountId,
+      defaultCode: regionConfig?.accountCodes.sales ?? null,
+      defaultName: regionConfig?.accountNames.sales ?? null,
+    },
+    {
+      label: 'Expense account',
+      description: 'Account where absorbed invoice payment fees are recorded as expenses in Xero.',
+      field: 'expenseAccountId',
+      accounts: xeroAccounts.expense,
+      selectedAccountId: expenseAccountId,
+      defaultCode: regionConfig?.accountCodes.merchantFees ?? null,
+      defaultName: regionConfig?.accountNames.expense ?? null,
+    },
+    {
+      label: 'Bank account',
+      description:
+        'Account the absorbed invoice payment fees are paid out of, paired with the expense account above.',
+      field: 'bankAccountId',
+      accounts: xeroAccounts.bank,
+      selectedAccountId: bankAccountId,
+      defaultCode: regionConfig?.accountCodes.bank ?? null,
+      defaultName: regionConfig?.accountNames.asset ?? null,
+    },
+  ]
+
+  return (
+    <div className="mt-2 mb-6">
+      {rows.map((row) => (
+        <AccountSelect
+          key={row.field}
+          label={row.label}
+          description={row.description}
+          field={row.field}
+          accounts={row.accounts}
+          selectedAccountId={row.selectedAccountId}
+          defaultCode={row.defaultCode}
+          defaultName={row.defaultName}
+          defaultIsArchived={isDefaultArchived(row.defaultCode)}
+          openDropdownId={openDropdownId}
+          setOpenDropdownId={setOpenDropdownId}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/features/settings/components/AccountMapping/index.tsx
+++ b/src/features/settings/components/AccountMapping/index.tsx
@@ -20,7 +20,7 @@ export const AccountMapping = () => {
 
   // An archived default code can't be recreated, so force an explicit selection.
   const isDefaultArchived = (defaultCode: string | null): boolean =>
-    defaultCode !== null && xeroAccounts.archivedAccountCodes.includes(defaultCode)
+    !!defaultCode && xeroAccounts.archivedAccountCodes.includes(defaultCode)
 
   const rows: {
     label: string

--- a/src/features/settings/components/ConfirmSettings.tsx
+++ b/src/features/settings/components/ConfirmSettings.tsx
@@ -10,7 +10,7 @@ import isDeepEqual from 'deep-equal'
 import { useState } from 'react'
 
 interface ConfirmSettingsProps {
-  mode: 'product' | 'invoice'
+  mode: 'product' | 'invoice' | 'account'
 }
 
 export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
@@ -22,6 +22,9 @@ export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
     productMappings,
     addAbsorbedFees,
     useCompanyName,
+    incomeAccountId,
+    bankAccountId,
+    expenseAccountId,
     updateSettings,
   } = useSettingsContext()
 
@@ -29,18 +32,26 @@ export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
 
   const [isPending, setIsPending] = useState(false)
 
-  const [initialMapping, showButtons] =
-    mode === 'product'
-      ? [
-          initialProductSettingsMapping,
-          syncProductsAutomatically !== initialSettings.syncProductsAutomatically ||
-            !isDeepEqual(productMappings, initialSettings.productMappings),
-        ]
-      : [
-          initialInvoiceSettingsMapping,
-          addAbsorbedFees !== initialSettings.addAbsorbedFees ||
-            useCompanyName !== initialSettings.useCompanyName,
-        ]
+  let initialMapping: boolean
+  let showButtons: boolean
+  if (mode === 'product') {
+    initialMapping = initialProductSettingsMapping
+    showButtons =
+      syncProductsAutomatically !== initialSettings.syncProductsAutomatically ||
+      !isDeepEqual(productMappings, initialSettings.productMappings)
+  } else if (mode === 'invoice') {
+    initialMapping = initialInvoiceSettingsMapping
+    showButtons =
+      addAbsorbedFees !== initialSettings.addAbsorbedFees ||
+      useCompanyName !== initialSettings.useCompanyName
+  } else {
+    // No first-time flag for accounts; show controls only when there are changes.
+    initialMapping = true
+    showButtons =
+      incomeAccountId !== initialSettings.incomeAccountId ||
+      bankAccountId !== initialSettings.bankAccountId ||
+      expenseAccountId !== initialSettings.expenseAccountId
+  }
 
   const onConfirm = async (e: React.MouseEvent) => {
     e.stopPropagation()
@@ -50,7 +61,6 @@ export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
 
     setIsPending(true)
     try {
-      // --- Apply confirm / update action for Product section of the form
       if (mode === 'product') {
         updateSettings({ initialProductSettingsMapping: true })
 
@@ -70,14 +80,26 @@ export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
           ...newSettings,
           productMappings: newMappings,
         })
-      } else {
+      } else if (mode === 'invoice') {
         updateSettings({ initialInvoiceSettingsMapping: true })
 
-        // --- Apply confirm action for Invoice section of the form
         const newSettings = await updateSettingsAction(user.token, {
           addAbsorbedFees,
           useCompanyName,
           initialInvoiceSettingsMapping: true,
+        })
+        updateSettings({
+          initialSettings: {
+            ...initialSettings,
+            ...newSettings,
+          },
+          ...newSettings,
+        })
+      } else {
+        const newSettings = await updateSettingsAction(user.token, {
+          incomeAccountId,
+          bankAccountId,
+          expenseAccountId,
         })
         updateSettings({
           initialSettings: {
@@ -104,10 +126,16 @@ export const ConfirmSettings = ({ mode }: ConfirmSettingsProps) => {
             syncProductsAutomatically: initialSettings.syncProductsAutomatically,
             productMappings: initialSettings.productMappings,
           }
-        : {
-            addAbsorbedFees: initialSettings.addAbsorbedFees,
-            useCompanyName: initialSettings.useCompanyName,
-          }
+        : mode === 'invoice'
+          ? {
+              addAbsorbedFees: initialSettings.addAbsorbedFees,
+              useCompanyName: initialSettings.useCompanyName,
+            }
+          : {
+              incomeAccountId: initialSettings.incomeAccountId,
+              bankAccountId: initialSettings.bankAccountId,
+              expenseAccountId: initialSettings.expenseAccountId,
+            }
     updateSettings(resetPayload)
   }
 

--- a/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
+++ b/src/features/settings/components/ProductMapping/ProductMappingTableRow.tsx
@@ -1,9 +1,8 @@
 import { useAuthContext } from '@auth/hooks/useAuth'
 import type { ProductMapping } from '@items-sync/types'
-import { useDropdown } from '@settings/hooks/useDropdown'
 import { useSettingsContext } from '@settings/hooks/useSettings'
 import { Icon } from 'copilot-design-system'
-import { useEffect, useRef, useState } from 'react'
+import { SearchableSelectMenu } from '@/components/ui/SearchableSelectMenu'
 import { formatCurrencyForRegion } from '@/lib/xero/region'
 import type { ClientXeroItem } from '@/lib/xero/types'
 
@@ -18,82 +17,27 @@ export const ProductMappingTableRow = ({
   openDropdownId,
   setOpenDropdownId,
 }: ProductMappingTableRowProps) => {
-  const { dropdownRef } = useDropdown({ setOpenDropdownId })
   const { productMappings, updateSettings, xeroItems, dropdownXeroItems } = useSettingsContext()
   const { countryCode } = useAuthContext()
 
   const xeroItem = xeroItems.find((i) => i.itemID === item.item?.itemID)
-
-  const [searchQuery, setSearchQuery] = useState('')
-  const [focusedIndex, setFocusedIndex] = useState(-1)
-  const listRef = useRef<HTMLDivElement>(null)
-
-  const filteredItems = dropdownXeroItems.filter((item) =>
-    item.name.toLowerCase().includes(searchQuery.toLowerCase()),
-  )
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: To set focused index
-  useEffect(() => {
-    setFocusedIndex(-1)
-  }, [searchQuery])
-
-  useEffect(() => {
-    if (openDropdownId === null) {
-      setSearchQuery('')
-    }
-  }, [openDropdownId])
-
-  useEffect(() => {
-    if (listRef.current && filteredItems.length > 0) {
-      const focusedElement = listRef.current.children[focusedIndex] as HTMLElement
-      if (focusedElement) {
-        focusedElement.scrollIntoView({ block: 'nearest' })
-      }
-    }
-  }, [focusedIndex, filteredItems.length])
-
-  const handleKeyDown = (e: React.KeyboardEvent) => {
-    if (e.key === 'ArrowDown') {
-      e.preventDefault()
-      setFocusedIndex((prev) => (prev === -1 ? 0 : Math.min(prev + 1, filteredItems.length - 1)))
-    } else if (e.key === 'ArrowUp') {
-      e.preventDefault()
-      setFocusedIndex((prev) => (prev === -1 ? filteredItems.length - 1 : Math.max(prev - 1, 0)))
-    } else if (e.key === 'Enter') {
-      e.preventDefault()
-      if (filteredItems[focusedIndex]) {
-        handleSelectMapping(filteredItems[focusedIndex])
-      }
-    } else if (e.key === 'Escape') {
-      e.preventDefault()
-      setOpenDropdownId(null)
-    }
-  }
+  const isOpen = item.product.id === openDropdownId
 
   const excludeItemFromMapping = () => {
-    const newProductMappings = productMappings.map((m) => {
-      if (m.product.id === item.product.id) {
-        return { ...m, item: null }
-      }
-      return m
-    })
+    const newProductMappings = productMappings.map((mapping) =>
+      mapping.product.id === item.product.id ? { ...mapping, item: null } : mapping,
+    )
     updateSettings({ productMappings: newProductMappings })
-    setOpenDropdownId(null)
   }
 
   const handleSelectMapping = (newItem: ClientXeroItem) => {
     const { itemID, name, code } = newItem
-    const newProductMappings = productMappings.map((mapping) => {
-      if (mapping.product.id === item.product.id) {
-        return {
-          ...mapping,
-          item: { itemID, name, code },
-        }
-      }
-      return mapping
-    })
+    const newProductMappings = productMappings.map((mapping) =>
+      mapping.product.id === item.product.id
+        ? { ...mapping, item: { itemID, name, code } }
+        : mapping,
+    )
     updateSettings({ productMappings: newProductMappings })
-    setOpenDropdownId(null)
   }
 
   const renderCurrency = (amount: number) => formatCurrencyForRegion(amount, countryCode)
@@ -139,65 +83,34 @@ export const ProductMappingTableRow = ({
             )}
           </div>
           <div className="col-span-1 my-auto ml-auto">
-            <Icon icon="ChevronDown" width={16} height={16} className={`text-gray-500`} />
+            <Icon icon="ChevronDown" width={16} height={16} className="text-gray-500" />
           </div>
         </button>
 
-        {/* Dropdown */}
-        {item.product.id === openDropdownId && (
-          <div
-            ref={dropdownRef}
-            className="items-dropdown !shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-[-1px] left-[-145px] z-100 mt-[-4px] rounded-sm border border-dropdown-border bg-white md:left-[-1px] md:min-w-[320px]"
-          >
-            <div className="px-3 py-2">
-              <input
-                type="text"
-                placeholder="Search"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                onKeyDown={handleKeyDown}
-                // biome-ignore lint/a11y/noAutofocus: Can't be bothered to change this atm
-                autoFocus
-                className="w-full text-sm focus:border-gray-500 focus:outline-none focus:ring-1 focus:ring-gray-500"
-              />
-            </div>
-
-            <div className="border-card-divider border-t-1 border-b-1 hover:bg-gray-100">
-              <button
-                type="button"
-                className="h-full w-full cursor-pointer px-3 py-2 text-left text-sm text-text-primary"
-                onClick={excludeItemFromMapping}
-              >
-                Exclude from mapping
-              </button>
-            </div>
-
-            {/* Dropdown options */}
-            <div className="max-h-56 overflow-y-auto" ref={listRef}>
-              {filteredItems?.length
-                ? Object.values(filteredItems).map((item, index) => (
-                    <button
-                      type="button"
-                      key={item.itemID}
-                      onClick={() => handleSelectMapping(item)}
-                      className={`mapping-option-btn flex w-full cursor-pointer items-center justify-between px-3 py-1.5 text-left text-sm transition-colors hover:bg-gray-100 ${
-                        index === focusedIndex ? 'bg-gray-100' : ''
-                      }`}
-                    >
-                      <span className="line-clamp-1 break-all text-text-primary lg:break-normal">
-                        {item.name}
-                      </span>
-                      <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
-                        {renderCurrency(item.amount)}
-                      </span>
-                    </button>
-                  ))
-                : ''}
-              {filteredItems.length === 0 && (
-                <div className="px-3 py-2 text-gray-500 text-sm">No items found</div>
-              )}
-            </div>
-          </div>
+        {isOpen && (
+          <SearchableSelectMenu
+            onClose={() => setOpenDropdownId(null)}
+            className="!shadow-[0_6px_20px_0_rgba(0,0,0,0.07)] absolute top-full right-[-1px] left-[-145px] z-100 mt-[-4px] rounded-sm border border-dropdown-border bg-white md:left-[-1px] md:min-w-[320px]"
+            options={dropdownXeroItems}
+            getOptionKey={(xero) => xero.itemID}
+            getSearchValues={(xero) => [xero.name]}
+            onSelect={handleSelectMapping}
+            emptyText="No items found"
+            action={{
+              render: () => 'Exclude from mapping',
+              onSelect: excludeItemFromMapping,
+            }}
+            renderOption={(xero) => (
+              <>
+                <span className="line-clamp-1 break-all text-text-primary lg:break-normal">
+                  {xero.name}
+                </span>
+                <span className="ps-2 text-body-micro text-gray-500 leading-body-micro">
+                  {renderCurrency(xero.amount)}
+                </span>
+              </>
+            )}
+          />
         )}
       </td>
     </tr>

--- a/src/features/settings/components/SettingsForm.tsx
+++ b/src/features/settings/components/SettingsForm.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { AccountMapping } from '@settings/components/AccountMapping'
 import { ConfirmSettings } from '@settings/components/ConfirmSettings'
 import { InvoiceDetails } from '@settings/components/InvoiceDetails'
 import { ProductMapping } from '@settings/components/ProductMapping'
@@ -29,6 +30,14 @@ export const SettingsForm = () => {
           title="Invoice Details"
           content=<InvoiceDetails />
           extra=<ConfirmSettings mode="invoice" />
+        />
+
+        <Divider />
+
+        <Accordion
+          title="Account Mapping"
+          content=<AccountMapping />
+          extra=<ConfirmSettings mode="account" />
         />
       </form>
     </div>

--- a/src/features/settings/context/SettingsContext.tsx
+++ b/src/features/settings/context/SettingsContext.tsx
@@ -3,24 +3,28 @@
 import type { ProductMapping } from '@items-sync/types'
 import { createContext, type PropsWithChildren, useCallback, useState } from 'react'
 import type { SettingsFields } from '@/db/schema/settings.schema'
+import type { ClientXeroAccounts } from '@/lib/xero/accounts'
 import type { ClientXeroItem } from '@/lib/xero/types'
 
 type BaseSettingsContextType = SettingsFields & {
   productMappings: ProductMapping[]
 }
 
-type WithXeroItems = {
+type WithXeroData = {
   xeroItems: ClientXeroItem[]
+  xeroAccounts: ClientXeroAccounts
 }
 
 export type SettingsContextType = BaseSettingsContextType & {
   initialSettings: BaseSettingsContextType
-} & WithXeroItems
+} & WithXeroData
 
 export const SettingsContext = createContext<
   | (SettingsContextType & {
       setSettings: React.Dispatch<React.SetStateAction<SettingsContextType>>
-      updateSettings: (state: Partial<SettingsContextType>) => void
+      updateSettings: (
+        state: Omit<Partial<SettingsContextType>, 'xeroItems' | 'xeroAccounts'>,
+      ) => void
     })
   | null
 >(null)
@@ -38,8 +42,9 @@ export const SettingsContextProvider = ({
   expenseAccountId,
   productMappings,
   xeroItems,
+  xeroAccounts,
   children,
-}: BaseSettingsContextType & PropsWithChildren & WithXeroItems) => {
+}: BaseSettingsContextType & PropsWithChildren & WithXeroData) => {
   const [settings, setSettings] = useState<SettingsContextType>({
     syncProductsAutomatically,
     addAbsorbedFees,
@@ -53,6 +58,7 @@ export const SettingsContextProvider = ({
     bankAccountId,
     expenseAccountId,
     xeroItems,
+    xeroAccounts,
 
     initialSettings: {
       syncProductsAutomatically,
@@ -69,9 +75,12 @@ export const SettingsContextProvider = ({
     },
   })
 
-  const updateSettings = useCallback((state: Omit<Partial<SettingsContextType>, 'xeroItems'>) => {
-    setSettings((prev) => ({ ...prev, ...state }))
-  }, [])
+  const updateSettings = useCallback(
+    (state: Omit<Partial<SettingsContextType>, 'xeroItems' | 'xeroAccounts'>) => {
+      setSettings((prev) => ({ ...prev, ...state }))
+    },
+    [],
+  )
 
   return (
     <SettingsContext.Provider

--- a/src/features/settings/lib/XeroAccounts.service.ts
+++ b/src/features/settings/lib/XeroAccounts.service.ts
@@ -1,0 +1,37 @@
+import 'server-only'
+
+import { Account } from 'xero-node'
+import logger from '@/lib/logger'
+import AuthenticatedXeroService from '@/lib/xero/AuthenticatedXero.service'
+import { type ClientXeroAccounts, toClientXeroAccount } from '@/lib/xero/accounts'
+
+/** Delivers the tenant's accounts to the settings UI, grouped by role. */
+class XeroAccountsService extends AuthenticatedXeroService {
+  async getClientXeroAccounts(): Promise<ClientXeroAccounts> {
+    logger.info(
+      'XeroAccountsService#getClientXeroAccounts :: Getting client xero accounts for portalId',
+      this.user.portalId,
+    )
+
+    const accounts = await this.xero.getAccounts(this.connection.tenantId)
+
+    const grouped: ClientXeroAccounts = {
+      income: [],
+      bank: [],
+      expense: [],
+      archivedAccountCodes: [],
+    }
+    for (const account of accounts) {
+      const clientAccount = toClientXeroAccount(account)
+      if (clientAccount) {
+        grouped[clientAccount.category].push(clientAccount)
+      } else if (account.code && account.status && account.status !== Account.StatusEnum.ACTIVE) {
+        // Code reserved by an archived account; the UI blocks defaulting to it.
+        grouped.archivedAccountCodes.push(account.code)
+      }
+    }
+    return grouped
+  }
+}
+
+export default XeroAccountsService

--- a/src/lib/xero/accounts.ts
+++ b/src/lib/xero/accounts.ts
@@ -1,4 +1,4 @@
-import { type Account, AccountType } from 'xero-node'
+import { Account, AccountType } from 'xero-node'
 
 // Account types Xero accepts for each role. We only treat a configured account as a
 // conflict when its type genuinely can't back that transaction (not for equivalent types).
@@ -30,23 +30,35 @@ export const categorizeAccount = (account: Account): AccountCategory | null => {
   return null
 }
 
-// Client-safe shape passed to the settings UI (consumed by the UI ticket).
+// Client-safe shape passed to the settings UI.
 export interface ClientXeroAccount {
   accountId: string
-  // null when Xero omits the name; the UI layer decides the display fallback
+  // null when Xero omits the name
   name: string | null
   code: string | null
   category: AccountCategory
+  // Accepts payments. null for bank accounts (no such flag).
+  enablePaymentsToAccount: boolean | null
 }
 
-// Returns null for accounts with no usable id or no category we map.
+// Null for inactive accounts, or those with no id/category we map.
 export const toClientXeroAccount = (account: Account): ClientXeroAccount | null => {
   const category = categorizeAccount(account)
-  if (!account.accountID || !category) return null
+  if (!account.accountID || !category || account.status !== Account.StatusEnum.ACTIVE) return null
   return {
     accountId: account.accountID,
     name: account.name ?? null,
     code: account.code ?? null,
     category,
+    enablePaymentsToAccount: account.enablePaymentsToAccount ?? null,
   }
+}
+
+// Accounts grouped by role for the settings UI.
+export interface ClientXeroAccounts {
+  income: ClientXeroAccount[]
+  bank: ClientXeroAccount[]
+  expense: ClientXeroAccount[]
+  // Codes held by archived accounts; a default on one can't be recreated.
+  archivedAccountCodes: string[]
 }


### PR DESCRIPTION
## Summary

UI half of the Xero account-selection feature ([OUT-3887](https://linear.app/assemblycom/issue/OUT-3887)), stacked on top of the backend work in OUT-3886. Adds an **Account Mapping** settings accordion with three searchable dropdowns — Income, Expense, Bank — for choosing which Xero accounts the integration uses. The selected Xero `AccountID` persists to `settings`; an unset field falls back to the region default.

## What's included

- **`XeroAccounts` service + client types** — `getClientXeroAccounts()` fetches the tenant's chart of accounts, groups them into income/bank/expense (active only), and surfaces `archivedAccountCodes`. `ClientXeroAccount` now carries `enablePaymentsToAccount`.
- **Data delivery** — `page.tsx` fetches accounts in the existing `Promise.all` (with a safe fallback) and threads `xeroAccounts` through `SettingsContext` as a **read-only** field (excluded from `updateSettings`, like `xeroItems`).
- **`AccountSelect` + `AccountMapping`** — reusable searchable single-select dropdown (adapted from `ProductMappingTableRow`) and the three rows with per-account descriptions.
- **`ConfirmSettings` `mode="account"`** — dirty-check, save, and cancel/reset, consistent with the product/invoice sections. New accordion wired into `SettingsForm`.

## Behavior

- **Unset field** → resolves the region default by code and shows "Use default account (name - code)"; a "Use default account" option in the dropdown clears back to null.
- **Archived default** (code reserved by an archived account → sync can't recreate it) → "Default account unavailable — please select an account" (red), no default option.
- **Stale selection** (saved account archived/removed in Xero) → "Selected account unavailable" (red).
- **Dropdown lists** only active accounts; Income/Expense additionally require `enablePaymentsToAccount` (Bank accounts don't expose the flag, so they're not filtered).

## Verification

- `pnpm typecheck`, `pnpm lint`, `pnpm build` all pass.
- Reviewed via the fullstack code reviewer — no regressions; the one flagged label-wording item was addressed.
- No DB migration (columns already added in OUT-3886).

> Note: base is **OUT-3886** (stacked PR). No test framework exists in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)