### PR TITLE
OUT-3946: add integration tests for product.created webhook

### DIFF
--- a/test/fixtures/productCreated.webhook.ts
+++ b/test/fixtures/productCreated.webhook.ts
@@ -1,0 +1,14 @@
+import { type ProductCreatedWebhookSchema, ValidWebhookEvent } from '@invoice-sync/types'
+import { TEST_PRODUCT_ID } from '@test/helpers/seed'
+import type { z } from 'zod'
+
+const productCreatedPayload: z.input<typeof ProductCreatedWebhookSchema> = {
+  eventType: ValidWebhookEvent.ProductCreated,
+  data: {
+    id: TEST_PRODUCT_ID,
+    name: 'Test Product',
+    description: 'A great test product',
+  },
+}
+
+export default productCreatedPayload

--- a/test/fixtures/productCreated.webhook.ts
+++ b/test/fixtures/productCreated.webhook.ts
@@ -1,11 +1,11 @@
 import { type ProductCreatedWebhookSchema, ValidWebhookEvent } from '@invoice-sync/types'
-import { TEST_PRODUCT_ID } from '@test/helpers/seed'
+import { TEST_PRODUCT } from '@test/helpers/constants'
 import type { z } from 'zod'
 
 const productCreatedPayload: z.input<typeof ProductCreatedWebhookSchema> = {
   eventType: ValidWebhookEvent.ProductCreated,
   data: {
-    id: TEST_PRODUCT_ID,
+    id: TEST_PRODUCT.id,
     name: 'Test Product',
     description: 'A great test product',
   },

--- a/test/helpers/constants.ts
+++ b/test/helpers/constants.ts
@@ -1,0 +1,25 @@
+// Shared identifiers for integration tests. Kept separate from seed.ts so files
+// that only need an id don't pull in the DB-heavy seed module.
+
+// The seeded workspace. tenantId/internalUserId are valid v4 uuids (version
+// nibble 4, variant nibble 8) so z.uuid() accepts them.
+export const TEST_PORTAL = {
+  id: 'test-portal-00000001',
+  tenantId: '11111111-1111-4111-8111-111111111111',
+  internalUserId: '22222222-2222-4222-8222-222222222222',
+}
+
+// Copilot webhook token + Xero OAuth token stubs.
+export const TEST_TOKENS = {
+  webhook: 'test-token-xyz',
+  access: 'test-access-token',
+  refresh: 'test-refresh-token',
+}
+
+// A Copilot product and the Xero item it maps to. `other` is a second item id
+// for asserting a pre-existing mapping is left untouched.
+export const TEST_PRODUCT = { id: '33333333-3333-4333-8333-333333333333' }
+export const TEST_XERO_ITEM = {
+  id: '44444444-4444-4444-8444-444444444444',
+  other: '99999999-9999-4999-8999-999999999999',
+}

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -1,4 +1,4 @@
-import { TEST_INTERNAL_USER_ID, TEST_PORTAL_ID, TEST_XERO_ITEM_ID } from '@test/helpers/seed'
+import { TEST_PORTAL, TEST_XERO_ITEM } from '@test/helpers/constants'
 import { type Mock, vi } from 'vitest'
 import { CopilotAPI } from '@/lib/copilot/CopilotAPI'
 import XeroAPI from '@/lib/xero/XeroAPI'
@@ -18,8 +18,8 @@ type XeroAPIOverrides = MockMethodOverrides<XeroAPI>
 export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
   return {
     getTokenPayload: vi.fn().mockResolvedValue({
-      workspaceId: TEST_PORTAL_ID,
-      internalUserId: TEST_INTERNAL_USER_ID,
+      workspaceId: TEST_PORTAL.id,
+      internalUserId: TEST_PORTAL.internalUserId,
     }),
     ...overrides,
   }
@@ -29,7 +29,7 @@ export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
 // - setTokenSet: no-op (called in the service constructor)
 // - getOrganisationCountryCode: a supported region, so no live call
 // - createItems: echoes the code and gives each item a unique uuid, like real
-//   Xero. The first item keeps TEST_XERO_ITEM_ID for single-product asserts.
+//   Xero. The first item keeps TEST_XERO_ITEM.id for single-product asserts.
 export function createMockXeroAPI(overrides: XeroAPIOverrides = {}) {
   return {
     setTokenSet: vi.fn(),
@@ -38,7 +38,7 @@ export function createMockXeroAPI(overrides: XeroAPIOverrides = {}) {
       items.map((item, index) => ({
         itemID:
           index === 0
-            ? TEST_XERO_ITEM_ID
+            ? TEST_XERO_ITEM.id
             : `44444444-4444-4444-8444-${String(index).padStart(12, '0')}`,
         code: item.code,
         name: item.name,

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -1,7 +1,10 @@
-import { TEST_INTERNAL_USER_ID, TEST_PORTAL_ID } from '@test/helpers/seed'
+import { TEST_INTERNAL_USER_ID, TEST_PORTAL_ID, TEST_XERO_ITEM_ID } from '@test/helpers/seed'
 import { type Mock, vi } from 'vitest'
 import { CopilotAPI } from '@/lib/copilot/CopilotAPI'
 import XeroAPI from '@/lib/xero/XeroAPI'
+
+// Minimal shape of the item payload SyncedItemsService sends to Xero.
+type CreateItemInput = { code: string; name: string; description?: string }
 
 // Restricts override keys to the actual method names of the underlying class so
 // typos produce a compile-time error. The Mock value type stays loose — tests
@@ -31,11 +34,21 @@ export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
  * Factory for a mocked XeroAPI instance. `setTokenSet` is a no-op spy because
  * AuthenticatedXeroService calls it in its constructor. `getOrganisationCountryCode`
  * defaults to a supported region so RegionService resolves without a live call.
+ * `createItems` echoes the input code (so the productId mapping resolves) and
+ * assigns a valid uuid itemID (persisted into the uuid `synced_items.item_id`).
  */
 export function createMockXeroAPI(overrides: XeroAPIOverrides = {}) {
   return {
     setTokenSet: vi.fn(),
     getOrganisationCountryCode: vi.fn().mockResolvedValue('US'),
+    createItems: vi.fn(async (_tenantId: string, items: CreateItemInput[]) =>
+      items.map((item) => ({
+        itemID: TEST_XERO_ITEM_ID,
+        code: item.code,
+        name: item.name,
+        description: item.description,
+      })),
+    ),
     ...overrides,
   }
 }

--- a/test/helpers/mocks.ts
+++ b/test/helpers/mocks.ts
@@ -6,9 +6,7 @@ import XeroAPI from '@/lib/xero/XeroAPI'
 // Minimal shape of the item payload SyncedItemsService sends to Xero.
 type CreateItemInput = { code: string; name: string; description?: string }
 
-// Restricts override keys to the actual method names of the underlying class so
-// typos produce a compile-time error. The Mock value type stays loose — tests
-// routinely return shapes that don't match the real Promise return type.
+// Only real method names can be overridden, so typos fail at compile time.
 type MockMethodOverrides<T> = {
   [K in keyof T as T[K] extends (...args: never[]) => unknown ? K : never]?: Mock
 }
@@ -16,10 +14,7 @@ type MockMethodOverrides<T> = {
 type CopilotAPIOverrides = MockMethodOverrides<CopilotAPI>
 type XeroAPIOverrides = MockMethodOverrides<XeroAPI>
 
-/**
- * Factory for a mocked CopilotAPI instance. Override any method via `overrides`
- * to tailor behavior per test.
- */
+// Mocked CopilotAPI. Override any method per test via `overrides`.
 export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
   return {
     getTokenPayload: vi.fn().mockResolvedValue({
@@ -30,20 +25,21 @@ export function createMockCopilotAPI(overrides: CopilotAPIOverrides = {}) {
   }
 }
 
-/**
- * Factory for a mocked XeroAPI instance. `setTokenSet` is a no-op spy because
- * AuthenticatedXeroService calls it in its constructor. `getOrganisationCountryCode`
- * defaults to a supported region so RegionService resolves without a live call.
- * `createItems` echoes the input code (so the productId mapping resolves) and
- * assigns a valid uuid itemID (persisted into the uuid `synced_items.item_id`).
- */
+// Mocked XeroAPI. Defaults cover the product.created happy path:
+// - setTokenSet: no-op (called in the service constructor)
+// - getOrganisationCountryCode: a supported region, so no live call
+// - createItems: echoes the code and gives each item a unique uuid, like real
+//   Xero. The first item keeps TEST_XERO_ITEM_ID for single-product asserts.
 export function createMockXeroAPI(overrides: XeroAPIOverrides = {}) {
   return {
     setTokenSet: vi.fn(),
     getOrganisationCountryCode: vi.fn().mockResolvedValue('US'),
     createItems: vi.fn(async (_tenantId: string, items: CreateItemInput[]) =>
-      items.map((item) => ({
-        itemID: TEST_XERO_ITEM_ID,
+      items.map((item, index) => ({
+        itemID:
+          index === 0
+            ? TEST_XERO_ITEM_ID
+            : `44444444-4444-4444-8444-${String(index).padStart(12, '0')}`,
         code: item.code,
         name: item.name,
         description: item.description,
@@ -56,14 +52,9 @@ export function createMockXeroAPI(overrides: XeroAPIOverrides = {}) {
 export type MockCopilotAPI = ReturnType<typeof createMockCopilotAPI>
 export type MockXeroAPI = ReturnType<typeof createMockXeroAPI>
 
-/**
- * Wires the module-mocked CopilotAPI + XeroAPI constructors to shared instances
- * and returns them so tests can assert on calls. Uses `function` (not arrow) so
- * the mock is callable with `new`.
- *
- * Caveat: one request may construct CopilotAPI several times (auth + sync flow) —
- * all share this instance, so call counts sum across sites.
- */
+// Points the CopilotAPI + XeroAPI constructors at shared mock instances and
+// returns them so tests can assert on calls. Uses `function` so `new` works.
+// Note: a request may build CopilotAPI more than once, so call counts add up.
 export function installMockApis(opts: { copilot?: MockCopilotAPI; xero?: MockXeroAPI } = {}): {
   copilot: MockCopilotAPI
   xero: MockXeroAPI

--- a/test/helpers/productCreatedTestSetup.ts
+++ b/test/helpers/productCreatedTestSetup.ts
@@ -1,0 +1,30 @@
+import { installMockApis, type MockCopilotAPI, type MockXeroAPI } from '@test/helpers/mocks'
+import { truncateAllTestTables } from '@test/helpers/testDb'
+import { beforeEach } from 'vitest'
+
+type InstallOpts = Parameters<typeof installMockApis>[0]
+
+export interface ProductCreatedTestHandle {
+  copilot: MockCopilotAPI
+  xero: MockXeroAPI
+}
+
+/**
+ * Registers the standard `beforeEach` (truncate + installMockApis) for
+ * product.created integration tests. Returns a live handle whose `copilot` /
+ * `xero` are replaced with fresh mock instances before each test. `optsFactory`
+ * runs per test so overrides get freshly instantiated `vi.fn()`s.
+ * Mock call history is reset by `clearMocks: true` in vitest.config.ts.
+ */
+export function setupProductCreatedTest(optsFactory?: () => InstallOpts): ProductCreatedTestHandle {
+  const handle = {} as ProductCreatedTestHandle
+
+  beforeEach(async () => {
+    await truncateAllTestTables()
+    const { copilot, xero } = installMockApis(optsFactory?.())
+    handle.copilot = copilot
+    handle.xero = xero
+  })
+
+  return handle
+}

--- a/test/helpers/productCreatedTestSetup.ts
+++ b/test/helpers/productCreatedTestSetup.ts
@@ -9,13 +9,9 @@ export interface ProductCreatedTestHandle {
   xero: MockXeroAPI
 }
 
-/**
- * Registers the standard `beforeEach` (truncate + installMockApis) for
- * product.created integration tests. Returns a live handle whose `copilot` /
- * `xero` are replaced with fresh mock instances before each test. `optsFactory`
- * runs per test so overrides get freshly instantiated `vi.fn()`s.
- * Mock call history is reset by `clearMocks: true` in vitest.config.ts.
- */
+// beforeEach for product.created tests: truncates the DB and installs fresh
+// mocks. Returns a handle with the current test's copilot/xero mocks.
+// `optsFactory` runs per test so overrides get fresh vi.fn()s.
 export function setupProductCreatedTest(optsFactory?: () => InstallOpts): ProductCreatedTestHandle {
   const handle = {} as ProductCreatedTestHandle
 

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -1,22 +1,10 @@
+import { TEST_PORTAL, TEST_PRODUCT, TEST_TOKENS, TEST_XERO_ITEM } from '@test/helpers/constants'
 import type { InferInsertModel } from 'drizzle-orm'
 import type { TokenSet } from 'xero-node'
 import db from '@/db'
 import { settings } from '@/db/schema/settings.schema'
 import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { xeroConnections } from '@/db/schema/xeroConnections.schema'
-
-export const TEST_PORTAL_ID = 'test-portal-00000001'
-// Valid v4 uuids (version nibble 4, variant nibble 8) — z.uuid() validates both.
-export const TEST_TENANT_ID = '11111111-1111-4111-8111-111111111111'
-export const TEST_INTERNAL_USER_ID = '22222222-2222-4222-8222-222222222222'
-export const TEST_WEBHOOK_TOKEN = 'test-token-xyz'
-export const TEST_ACCESS_TOKEN = 'test-access-token'
-export const TEST_REFRESH_TOKEN = 'test-refresh-token'
-// Copilot product id and the Xero item id it maps to (both stored in uuid columns).
-export const TEST_PRODUCT_ID = '33333333-3333-4333-8333-333333333333'
-export const TEST_XERO_ITEM_ID = '44444444-4444-4444-8444-444444444444'
-// A second Xero item id, for asserting a pre-existing mapping is left untouched.
-export const TEST_OTHER_XERO_ITEM_ID = '99999999-9999-4999-8999-999999999999'
 
 type ConnectionOverrides = Partial<InferInsertModel<typeof xeroConnections>>
 type SettingsOverrides = Partial<InferInsertModel<typeof settings>>
@@ -25,19 +13,19 @@ type SettingsOverrides = Partial<InferInsertModel<typeof settings>>
 // Cast because we only store the TokenSet JSON fields.
 function buildBaseConnection(): InferInsertModel<typeof xeroConnections> {
   const validTokenSet = {
-    access_token: TEST_ACCESS_TOKEN,
-    refresh_token: TEST_REFRESH_TOKEN,
+    access_token: TEST_TOKENS.access,
+    refresh_token: TEST_TOKENS.refresh,
     expires_at: Math.floor(Date.now() / 1000) + 3600,
     expires_in: 3600,
     token_type: 'Bearer',
     scope: 'accounting.transactions accounting.contacts offline_access',
   }
   return {
-    portalId: TEST_PORTAL_ID,
-    tenantId: TEST_TENANT_ID,
+    portalId: TEST_PORTAL.id,
+    tenantId: TEST_PORTAL.tenantId,
     tokenSet: validTokenSet as unknown as TokenSet,
     status: true,
-    initiatedBy: TEST_INTERNAL_USER_ID,
+    initiatedBy: TEST_PORTAL.internalUserId,
   }
 }
 
@@ -50,8 +38,8 @@ export async function seedXeroConnection(overrides: ConnectionOverrides = {}) {
 }
 
 const baseSettings: InferInsertModel<typeof settings> = {
-  portalId: TEST_PORTAL_ID,
-  tenantId: TEST_TENANT_ID,
+  portalId: TEST_PORTAL.id,
+  tenantId: TEST_PORTAL.tenantId,
   // Cache a supported country so RegionService doesn't call live Xero.
   countryCode: 'US',
   isSyncEnabled: true,
@@ -80,10 +68,10 @@ export async function seedConnectedPortal(
 type SyncedItemOverrides = Partial<InferInsertModel<typeof syncedItems>>
 
 const baseSyncedItem: InferInsertModel<typeof syncedItems> = {
-  portalId: TEST_PORTAL_ID,
-  tenantId: TEST_TENANT_ID,
-  productId: TEST_PRODUCT_ID,
-  itemId: TEST_XERO_ITEM_ID,
+  portalId: TEST_PORTAL.id,
+  tenantId: TEST_PORTAL.tenantId,
+  productId: TEST_PRODUCT.id,
+  itemId: TEST_XERO_ITEM.id,
 }
 
 export async function seedSyncedItem(overrides: SyncedItemOverrides = {}) {

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -21,8 +21,8 @@ export const TEST_OTHER_XERO_ITEM_ID = '99999999-9999-4999-8999-999999999999'
 type ConnectionOverrides = Partial<InferInsertModel<typeof xeroConnections>>
 type SettingsOverrides = Partial<InferInsertModel<typeof settings>>
 
-// Built per seed so expires_at stays in the future on long runs, keeping the
-// token valid. Cast because we store only the TokenSet JSON fields.
+// Built per seed so expires_at stays in the future, keeping the token valid.
+// Cast because we only store the TokenSet JSON fields.
 function buildBaseConnection(): InferInsertModel<typeof xeroConnections> {
   const validTokenSet = {
     access_token: TEST_ACCESS_TOKEN,
@@ -68,10 +68,7 @@ export async function seedSettings(overrides: SettingsOverrides = {}) {
   return row
 }
 
-/**
- * Seeds the common "healthy connected portal" fixture: an active Xero
- * connection plus sync-enabled settings for the same portal x tenant.
- */
+// Seeds an active Xero connection plus sync-enabled settings for one portal.
 export async function seedConnectedPortal(
   opts: { connection?: ConnectionOverrides; settings?: SettingsOverrides } = {},
 ) {

--- a/test/helpers/seed.ts
+++ b/test/helpers/seed.ts
@@ -2,14 +2,21 @@ import type { InferInsertModel } from 'drizzle-orm'
 import type { TokenSet } from 'xero-node'
 import db from '@/db'
 import { settings } from '@/db/schema/settings.schema'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { xeroConnections } from '@/db/schema/xeroConnections.schema'
 
 export const TEST_PORTAL_ID = 'test-portal-00000001'
-export const TEST_TENANT_ID = '11111111-1111-1111-1111-111111111111'
-export const TEST_INTERNAL_USER_ID = '22222222-2222-2222-2222-222222222222'
+// Valid v4 uuids (version nibble 4, variant nibble 8) — z.uuid() validates both.
+export const TEST_TENANT_ID = '11111111-1111-4111-8111-111111111111'
+export const TEST_INTERNAL_USER_ID = '22222222-2222-4222-8222-222222222222'
 export const TEST_WEBHOOK_TOKEN = 'test-token-xyz'
 export const TEST_ACCESS_TOKEN = 'test-access-token'
 export const TEST_REFRESH_TOKEN = 'test-refresh-token'
+// Copilot product id and the Xero item id it maps to (both stored in uuid columns).
+export const TEST_PRODUCT_ID = '33333333-3333-4333-8333-333333333333'
+export const TEST_XERO_ITEM_ID = '44444444-4444-4444-8444-444444444444'
+// A second Xero item id, for asserting a pre-existing mapping is left untouched.
+export const TEST_OTHER_XERO_ITEM_ID = '99999999-9999-4999-8999-999999999999'
 
 type ConnectionOverrides = Partial<InferInsertModel<typeof xeroConnections>>
 type SettingsOverrides = Partial<InferInsertModel<typeof settings>>
@@ -71,4 +78,21 @@ export async function seedConnectedPortal(
   const connection = await seedXeroConnection(opts.connection)
   const setting = await seedSettings(opts.settings)
   return { connection, setting }
+}
+
+type SyncedItemOverrides = Partial<InferInsertModel<typeof syncedItems>>
+
+const baseSyncedItem: InferInsertModel<typeof syncedItems> = {
+  portalId: TEST_PORTAL_ID,
+  tenantId: TEST_TENANT_ID,
+  productId: TEST_PRODUCT_ID,
+  itemId: TEST_XERO_ITEM_ID,
+}
+
+export async function seedSyncedItem(overrides: SyncedItemOverrides = {}) {
+  const [row] = await db
+    .insert(syncedItems)
+    .values({ ...baseSyncedItem, ...overrides })
+    .returning()
+  return row
 }

--- a/test/helpers/webhook.ts
+++ b/test/helpers/webhook.ts
@@ -1,4 +1,4 @@
-import { TEST_WEBHOOK_TOKEN } from '@test/helpers/seed'
+import { TEST_TOKENS } from '@test/helpers/constants'
 import { testApiHandler } from 'next-test-api-route-handler'
 import * as appHandler from '@/app/api/webhook/route'
 
@@ -11,7 +11,7 @@ export async function postWebhook(
   payload: unknown,
   opts: { token?: string } = {},
 ): Promise<Response> {
-  const token = opts.token ?? TEST_WEBHOOK_TOKEN
+  const token = opts.token ?? TEST_TOKENS.webhook
   let response: Response | undefined
   await testApiHandler({
     appHandler,

--- a/test/integration/harness.smoke.test.ts
+++ b/test/integration/harness.smoke.test.ts
@@ -1,4 +1,5 @@
-import { seedConnectedPortal, TEST_PORTAL_ID } from '@test/helpers/seed'
+import { TEST_PORTAL } from '@test/helpers/constants'
+import { seedConnectedPortal } from '@test/helpers/seed'
 import { truncateAllTestTables } from '@test/helpers/testDb'
 import { beforeEach, describe, expect, it } from 'vitest'
 import db from '@/db'
@@ -26,11 +27,11 @@ describe('integration harness', () => {
 
     const connections = await db.select().from(xeroConnections)
     expect(connections).toHaveLength(1)
-    expect(connections[0]).toMatchObject({ portalId: TEST_PORTAL_ID, status: true })
+    expect(connections[0]).toMatchObject({ portalId: TEST_PORTAL.id, status: true })
 
     const settingRows = await db.select().from(settings)
     expect(settingRows).toHaveLength(1)
-    expect(settingRows[0]).toMatchObject({ portalId: TEST_PORTAL_ID, isSyncEnabled: true })
+    expect(settingRows[0]).toMatchObject({ portalId: TEST_PORTAL.id, isSyncEnabled: true })
   })
 
   it('truncates between tests', async () => {

--- a/test/integration/webhook/productCreated/happyPath.test.ts
+++ b/test/integration/webhook/productCreated/happyPath.test.ts
@@ -11,6 +11,7 @@ import { postWebhook } from '@test/helpers/webhook'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
 import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { SyncEntityType, SyncEventType, SyncStatus, syncLogs } from '@/db/schema/syncLogs.schema'
 
@@ -57,5 +58,8 @@ describe('POST /api/webhook — product.created', () => {
       productName: 'Test Product',
       xeroItemName: 'Test Product',
     })
+
+    // No failure recorded on the happy path.
+    expect(await db.select().from(failedSyncs)).toHaveLength(0)
   })
 })

--- a/test/integration/webhook/productCreated/happyPath.test.ts
+++ b/test/integration/webhook/productCreated/happyPath.test.ts
@@ -1,0 +1,61 @@
+import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
+import {
+  seedConnectedPortal,
+  TEST_PORTAL_ID,
+  TEST_PRODUCT_ID,
+  TEST_TENANT_ID,
+  TEST_XERO_ITEM_ID,
+} from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import db from '@/db'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
+import { SyncEntityType, SyncEventType, SyncStatus, syncLogs } from '@/db/schema/syncLogs.schema'
+
+describe('POST /api/webhook — product.created', () => {
+  const apis = setupProductCreatedTest()
+
+  it('creates a Xero item, maps it in synced_items, and logs the sync as successful', async () => {
+    await seedConnectedPortal()
+
+    const res = await postWebhook(productCreatedPayload)
+    expect(res.status).toBe(200)
+
+    // Xero item created once for the connected tenant with the product details.
+    expect(apis.xero.createItems).toHaveBeenCalledTimes(1)
+    const [tenantId, itemsCreated] = apis.xero.createItems.mock.calls[0]
+    expect(tenantId).toBe(TEST_TENANT_ID)
+    expect(itemsCreated).toHaveLength(1)
+    expect(itemsCreated[0]).toMatchObject({
+      name: 'Test Product',
+      description: 'A great test product',
+      isPurchased: false,
+    })
+
+    // Product mapped to the Xero item.
+    const items = await db.select().from(syncedItems)
+    expect(items).toHaveLength(1)
+    expect(items[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      tenantId: TEST_TENANT_ID,
+      productId: TEST_PRODUCT_ID,
+      itemId: TEST_XERO_ITEM_ID,
+    })
+
+    // Success sync log written for the product.
+    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT_ID))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      tenantId: TEST_TENANT_ID,
+      entityType: SyncEntityType.PRODUCT,
+      eventType: SyncEventType.CREATED,
+      status: SyncStatus.SUCCESS,
+      xeroId: TEST_XERO_ITEM_ID,
+      productName: 'Test Product',
+      xeroItemName: 'Test Product',
+    })
+  })
+})

--- a/test/integration/webhook/productCreated/happyPath.test.ts
+++ b/test/integration/webhook/productCreated/happyPath.test.ts
@@ -1,12 +1,7 @@
 import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { TEST_PORTAL, TEST_PRODUCT, TEST_XERO_ITEM } from '@test/helpers/constants'
 import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
-import {
-  seedConnectedPortal,
-  TEST_PORTAL_ID,
-  TEST_PRODUCT_ID,
-  TEST_TENANT_ID,
-  TEST_XERO_ITEM_ID,
-} from '@test/helpers/seed'
+import { seedConnectedPortal } from '@test/helpers/seed'
 import { postWebhook } from '@test/helpers/webhook'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
@@ -27,7 +22,7 @@ describe('POST /api/webhook — product.created', () => {
     // Xero item created once for the connected tenant with the product details.
     expect(apis.xero.createItems).toHaveBeenCalledTimes(1)
     const [tenantId, itemsCreated] = apis.xero.createItems.mock.calls[0]
-    expect(tenantId).toBe(TEST_TENANT_ID)
+    expect(tenantId).toBe(TEST_PORTAL.tenantId)
     expect(itemsCreated).toHaveLength(1)
     expect(itemsCreated[0]).toMatchObject({
       name: 'Test Product',
@@ -39,22 +34,22 @@ describe('POST /api/webhook — product.created', () => {
     const items = await db.select().from(syncedItems)
     expect(items).toHaveLength(1)
     expect(items[0]).toMatchObject({
-      portalId: TEST_PORTAL_ID,
-      tenantId: TEST_TENANT_ID,
-      productId: TEST_PRODUCT_ID,
-      itemId: TEST_XERO_ITEM_ID,
+      portalId: TEST_PORTAL.id,
+      tenantId: TEST_PORTAL.tenantId,
+      productId: TEST_PRODUCT.id,
+      itemId: TEST_XERO_ITEM.id,
     })
 
     // Success sync log written for the product.
-    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT_ID))
+    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT.id))
     expect(logs).toHaveLength(1)
     expect(logs[0]).toMatchObject({
-      portalId: TEST_PORTAL_ID,
-      tenantId: TEST_TENANT_ID,
+      portalId: TEST_PORTAL.id,
+      tenantId: TEST_PORTAL.tenantId,
       entityType: SyncEntityType.PRODUCT,
       eventType: SyncEventType.CREATED,
       status: SyncStatus.SUCCESS,
-      xeroId: TEST_XERO_ITEM_ID,
+      xeroId: TEST_XERO_ITEM.id,
       productName: 'Test Product',
       xeroItemName: 'Test Product',
     })

--- a/test/integration/webhook/productCreated/idempotency.test.ts
+++ b/test/integration/webhook/productCreated/idempotency.test.ts
@@ -1,11 +1,7 @@
 import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { TEST_PRODUCT, TEST_XERO_ITEM } from '@test/helpers/constants'
 import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
-import {
-  seedConnectedPortal,
-  seedSyncedItem,
-  TEST_OTHER_XERO_ITEM_ID,
-  TEST_PRODUCT_ID,
-} from '@test/helpers/seed'
+import { seedConnectedPortal, seedSyncedItem } from '@test/helpers/seed'
 import { postWebhook } from '@test/helpers/webhook'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
@@ -22,7 +18,7 @@ describe('POST /api/webhook — product.created (already mapped)', () => {
 
   it('skips the Xero call and writes no new rows when the product is already mapped', async () => {
     await seedConnectedPortal()
-    await seedSyncedItem({ itemId: TEST_OTHER_XERO_ITEM_ID })
+    await seedSyncedItem({ itemId: TEST_XERO_ITEM.other })
 
     const res = await postWebhook(productCreatedPayload)
     expect(res.status).toBe(200)
@@ -34,9 +30,9 @@ describe('POST /api/webhook — product.created (already mapped)', () => {
     const items = await db
       .select()
       .from(syncedItems)
-      .where(eq(syncedItems.productId, TEST_PRODUCT_ID))
+      .where(eq(syncedItems.productId, TEST_PRODUCT.id))
     expect(items).toHaveLength(1)
-    expect(items[0].itemId).toBe(TEST_OTHER_XERO_ITEM_ID)
+    expect(items[0].itemId).toBe(TEST_XERO_ITEM.other)
 
     // Early return skips both logging and failure recording.
     expect(await db.select().from(syncLogs)).toHaveLength(0)

--- a/test/integration/webhook/productCreated/idempotency.test.ts
+++ b/test/integration/webhook/productCreated/idempotency.test.ts
@@ -10,15 +10,13 @@ import { postWebhook } from '@test/helpers/webhook'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it } from 'vitest'
 import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
 import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { syncLogs } from '@/db/schema/syncLogs.schema'
 
-// Re-sending product.created for an already-mapped product must not duplicate it.
-// This covers the getSyncedItemsMapByProductIds pre-check short-circuit. The
-// separate onConflictDoNothing orphan-cleanup branch in
-// SyncedItemsService#createItems only fires on a true insert-time race (a row
-// created between the pre-check and the insert), which can't be triggered
-// deterministically here, so it is intentionally not covered.
+// Re-sending product.created for a mapped product must not duplicate it. This
+// hits the pre-check that skips mapped products. The insert-time conflict branch
+// only fires on a real race, so it's left uncovered on purpose.
 describe('POST /api/webhook — product.created (already mapped)', () => {
   const apis = setupProductCreatedTest()
 
@@ -40,7 +38,8 @@ describe('POST /api/webhook — product.created (already mapped)', () => {
     expect(items).toHaveLength(1)
     expect(items[0].itemId).toBe(TEST_OTHER_XERO_ITEM_ID)
 
-    // Early return skips logging.
+    // Early return skips both logging and failure recording.
     expect(await db.select().from(syncLogs)).toHaveLength(0)
+    expect(await db.select().from(failedSyncs)).toHaveLength(0)
   })
 })

--- a/test/integration/webhook/productCreated/idempotency.test.ts
+++ b/test/integration/webhook/productCreated/idempotency.test.ts
@@ -1,0 +1,46 @@
+import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
+import {
+  seedConnectedPortal,
+  seedSyncedItem,
+  TEST_OTHER_XERO_ITEM_ID,
+  TEST_PRODUCT_ID,
+} from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import db from '@/db'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
+import { syncLogs } from '@/db/schema/syncLogs.schema'
+
+// Re-sending product.created for an already-mapped product must not duplicate it.
+// This covers the getSyncedItemsMapByProductIds pre-check short-circuit. The
+// separate onConflictDoNothing orphan-cleanup branch in
+// SyncedItemsService#createItems only fires on a true insert-time race (a row
+// created between the pre-check and the insert), which can't be triggered
+// deterministically here, so it is intentionally not covered.
+describe('POST /api/webhook — product.created (already mapped)', () => {
+  const apis = setupProductCreatedTest()
+
+  it('skips the Xero call and writes no new rows when the product is already mapped', async () => {
+    await seedConnectedPortal()
+    await seedSyncedItem({ itemId: TEST_OTHER_XERO_ITEM_ID })
+
+    const res = await postWebhook(productCreatedPayload)
+    expect(res.status).toBe(200)
+
+    // Existing-mapping check runs before any Xero call.
+    expect(apis.xero.createItems).not.toHaveBeenCalled()
+
+    // Still just the seeded row, unchanged.
+    const items = await db
+      .select()
+      .from(syncedItems)
+      .where(eq(syncedItems.productId, TEST_PRODUCT_ID))
+    expect(items).toHaveLength(1)
+    expect(items[0].itemId).toBe(TEST_OTHER_XERO_ITEM_ID)
+
+    // Early return skips logging.
+    expect(await db.select().from(syncLogs)).toHaveLength(0)
+  })
+})

--- a/test/integration/webhook/productCreated/isSyncDisabled.test.ts
+++ b/test/integration/webhook/productCreated/isSyncDisabled.test.ts
@@ -1,0 +1,29 @@
+import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
+import { seedConnectedPortal } from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { describe, expect, it } from 'vitest'
+import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
+import { syncLogs } from '@/db/schema/syncLogs.schema'
+
+// Controller-level gate: sync is disabled for the whole workspace, so the
+// controller short-circuits before the event is ever dispatched. Distinct from
+// the service-level syncProductsAutomatically gate.
+describe('POST /api/webhook — product.created (isSyncEnabled=false)', () => {
+  const apis = setupProductCreatedTest()
+
+  it('returns 200 without creating a Xero item or writing any rows', async () => {
+    await seedConnectedPortal({ settings: { isSyncEnabled: false } })
+
+    const res = await postWebhook(productCreatedPayload)
+    expect(res.status).toBe(200)
+
+    expect(apis.xero.createItems).not.toHaveBeenCalled()
+
+    expect(await db.select().from(syncedItems)).toHaveLength(0)
+    expect(await db.select().from(syncLogs)).toHaveLength(0)
+    expect(await db.select().from(failedSyncs)).toHaveLength(0)
+  })
+})

--- a/test/integration/webhook/productCreated/isSyncDisabled.test.ts
+++ b/test/integration/webhook/productCreated/isSyncDisabled.test.ts
@@ -8,9 +8,8 @@ import { failedSyncs } from '@/db/schema/failedSyncs.schema'
 import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { syncLogs } from '@/db/schema/syncLogs.schema'
 
-// Controller-level gate: sync is disabled for the whole workspace, so the
-// controller short-circuits before the event is ever dispatched. Distinct from
-// the service-level syncProductsAutomatically gate.
+// Workspace sync is off, so the controller stops before dispatching the event.
+// This is a different gate from syncProductsAutomatically.
 describe('POST /api/webhook — product.created (isSyncEnabled=false)', () => {
   const apis = setupProductCreatedTest()
 

--- a/test/integration/webhook/productCreated/syncProductsAutomaticallyDisabled.test.ts
+++ b/test/integration/webhook/productCreated/syncProductsAutomaticallyDisabled.test.ts
@@ -8,8 +8,8 @@ import { failedSyncs } from '@/db/schema/failedSyncs.schema'
 import { syncedItems } from '@/db/schema/syncedItems.schema'
 import { syncLogs } from '@/db/schema/syncLogs.schema'
 
-// Service-level gate: sync is enabled for the workspace, but automatic product
-// sync is off. See isSyncDisabled.test.ts for the controller-level gate.
+// Workspace sync is on, but automatic product sync is off, so the service skips
+// the product. See isSyncDisabled.test.ts for the workspace-level gate.
 describe('POST /api/webhook — product.created (syncProductsAutomatically=false)', () => {
   const apis = setupProductCreatedTest()
 

--- a/test/integration/webhook/productCreated/syncProductsAutomaticallyDisabled.test.ts
+++ b/test/integration/webhook/productCreated/syncProductsAutomaticallyDisabled.test.ts
@@ -1,0 +1,29 @@
+import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
+import { seedConnectedPortal } from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { describe, expect, it } from 'vitest'
+import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
+import { syncLogs } from '@/db/schema/syncLogs.schema'
+
+// Service-level gate: sync is enabled for the workspace, but automatic product
+// sync is off. See isSyncDisabled.test.ts for the controller-level gate.
+describe('POST /api/webhook — product.created (syncProductsAutomatically=false)', () => {
+  const apis = setupProductCreatedTest()
+
+  it('returns 200 without creating a Xero item or writing any rows', async () => {
+    await seedConnectedPortal({ settings: { syncProductsAutomatically: false } })
+
+    const res = await postWebhook(productCreatedPayload)
+    // Handler throws APIError with status OK, which handleEvent swallows.
+    expect(res.status).toBe(200)
+
+    expect(apis.xero.createItems).not.toHaveBeenCalled()
+
+    expect(await db.select().from(syncedItems)).toHaveLength(0)
+    expect(await db.select().from(syncLogs)).toHaveLength(0)
+    expect(await db.select().from(failedSyncs)).toHaveLength(0)
+  })
+})

--- a/test/integration/webhook/productCreated/xeroCreateItemFails.test.ts
+++ b/test/integration/webhook/productCreated/xeroCreateItemFails.test.ts
@@ -1,12 +1,8 @@
 import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { TEST_PORTAL, TEST_PRODUCT } from '@test/helpers/constants'
 import { createMockXeroAPI } from '@test/helpers/mocks'
 import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
-import {
-  seedConnectedPortal,
-  TEST_PORTAL_ID,
-  TEST_PRODUCT_ID,
-  TEST_TENANT_ID,
-} from '@test/helpers/seed'
+import { seedConnectedPortal } from '@test/helpers/seed'
 import { postWebhook } from '@test/helpers/webhook'
 import { eq } from 'drizzle-orm'
 import { describe, expect, it, vi } from 'vitest'
@@ -37,11 +33,11 @@ describe('POST /api/webhook — product.created (Xero createItems fails)', () =>
     expect(await db.select().from(syncedItems)).toHaveLength(0)
 
     // FAILED sync log written.
-    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT_ID))
+    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT.id))
     expect(logs).toHaveLength(1)
     expect(logs[0]).toMatchObject({
-      portalId: TEST_PORTAL_ID,
-      tenantId: TEST_TENANT_ID,
+      portalId: TEST_PORTAL.id,
+      tenantId: TEST_PORTAL.tenantId,
       entityType: SyncEntityType.PRODUCT,
       eventType: SyncEventType.CREATED,
       status: SyncStatus.FAILED,
@@ -53,13 +49,13 @@ describe('POST /api/webhook — product.created (Xero createItems fails)', () =>
     const failed = await db
       .select()
       .from(failedSyncs)
-      .where(eq(failedSyncs.resourceId, TEST_PRODUCT_ID))
+      .where(eq(failedSyncs.resourceId, TEST_PRODUCT.id))
     expect(failed).toHaveLength(1)
     expect(failed[0]).toMatchObject({
-      portalId: TEST_PORTAL_ID,
-      tenantId: TEST_TENANT_ID,
+      portalId: TEST_PORTAL.id,
+      tenantId: TEST_PORTAL.tenantId,
       type: 'product.created',
-      resourceId: TEST_PRODUCT_ID,
+      resourceId: TEST_PRODUCT.id,
     })
   })
 })

--- a/test/integration/webhook/productCreated/xeroCreateItemFails.test.ts
+++ b/test/integration/webhook/productCreated/xeroCreateItemFails.test.ts
@@ -1,0 +1,65 @@
+import productCreatedPayload from '@test/fixtures/productCreated.webhook'
+import { createMockXeroAPI } from '@test/helpers/mocks'
+import { setupProductCreatedTest } from '@test/helpers/productCreatedTestSetup'
+import {
+  seedConnectedPortal,
+  TEST_PORTAL_ID,
+  TEST_PRODUCT_ID,
+  TEST_TENANT_ID,
+} from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it, vi } from 'vitest'
+import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import { syncedItems } from '@/db/schema/syncedItems.schema'
+import { SyncEntityType, SyncEventType, SyncStatus, syncLogs } from '@/db/schema/syncLogs.schema'
+
+// createItems throws → no mapping row, but a FAILED sync log and a failed_syncs
+// record are written before the error is rethrown (500).
+describe('POST /api/webhook — product.created (Xero createItems fails)', () => {
+  const apis = setupProductCreatedTest(() => ({
+    xero: createMockXeroAPI({
+      createItems: vi.fn().mockRejectedValue(new Error('Xero is on fire')),
+    }),
+  }))
+
+  it('writes no mapping row, records a FAILED sync log + failed_syncs, and returns 500', async () => {
+    await seedConnectedPortal()
+
+    const res = await postWebhook(productCreatedPayload)
+    expect(res.status).toBe(500)
+
+    // Got far enough to attempt item creation.
+    expect(apis.xero.createItems).toHaveBeenCalledTimes(1)
+
+    // No mapping row persisted.
+    expect(await db.select().from(syncedItems)).toHaveLength(0)
+
+    // FAILED sync log written.
+    const logs = await db.select().from(syncLogs).where(eq(syncLogs.copilotId, TEST_PRODUCT_ID))
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      tenantId: TEST_TENANT_ID,
+      entityType: SyncEntityType.PRODUCT,
+      eventType: SyncEventType.CREATED,
+      status: SyncStatus.FAILED,
+      productName: 'Test Product',
+    })
+    expect(logs[0].errorMessage).toContain('Failed to create synced item')
+
+    // failed_syncs record queued for retry.
+    const failed = await db
+      .select()
+      .from(failedSyncs)
+      .where(eq(failedSyncs.resourceId, TEST_PRODUCT_ID))
+    expect(failed).toHaveLength(1)
+    expect(failed[0]).toMatchObject({
+      portalId: TEST_PORTAL_ID,
+      tenantId: TEST_TENANT_ID,
+      type: 'product.created',
+      resourceId: TEST_PRODUCT_ID,
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Integration tests for the `product.created` webhook flow, built on the testcontainers harness from [OUT-3933](https://linear.app/assemblycom/issue/OUT-3933/integration-test-setup-for-xero-integration) (assemblycom/xero-integration#64).

## Cases covered

* **happy path** — creates a Xero item, maps it in `synced_items`, writes a success `sync_log`.
* `syncProductsAutomatically=false` — service-level gate: 200, no Xero call, no rows.
* `isSyncEnabled=false` — controller-level gate (short-circuits before dispatch): 200, no Xero call, no rows.
* **already mapped** — pre-check short-circuits, no Xero call, seeded row unchanged, no log.
* `createItems` **fails** — no mapping row, FAILED `sync_log` + `failed_syncs` record, returns 500.

## Harness additions

* `productCreatedTestSetup.ts` — per-flow `beforeEach` (truncate + mock install) returning a live `{ copilot, xero }` handle.
* `productCreated.webhook.ts` fixture, `seedSyncedItem` seeder, and a `createItems` default on the Xero mock.

## Notes

* The two green guard tests were confirmed to fail-for-the-right-reason (watched them go red with the guard defeated).
* The `onConflictDoNothing` orphan-cleanup race branch is intentionally not covered — it only fires on a true insert-time race and can't be triggered deterministically (documented in `idempotency.test.ts`).

## Verification

* `pnpm typecheck` (src + test) — clean
* `biome check` — clean
* `pnpm test` — 8/8 passing (6 files)

🤖 Generated with [Claude Code](<https://claude.com/claude-code>)