### PR TITLE
OUT-3951: default sync-log entityType when paying without a prior created log

### DIFF
--- a/src/features/invoice-sync/lib/SyncedInvoices.service.ts
+++ b/src/features/invoice-sync/lib/SyncedInvoices.service.ts
@@ -308,6 +308,7 @@ class SyncedInvoicesService extends AuthenticatedXeroService {
         syncLogsService.setTx(tx)
         await syncLogsService.createSyncLog({
           ...prevSyncLog,
+          entityType: SyncEntityType.INVOICE,
           eventType: SyncEventType.PAID,
           status: SyncStatus.SUCCESS,
           syncDate: new Date(),

--- a/test/integration/webhook/invoicePaid/noPriorCreatedLog.test.ts
+++ b/test/integration/webhook/invoicePaid/noPriorCreatedLog.test.ts
@@ -1,0 +1,45 @@
+import { buildPaidInvoiceWebhook } from '@test/fixtures/paidInvoice.webhook'
+import { seedConnectedPortal, seedSyncedInvoice } from '@test/helpers/seed'
+import { postWebhook } from '@test/helpers/webhook'
+import { setupWebhookTest } from '@test/helpers/webhookTestSetup'
+import { eq } from 'drizzle-orm'
+import { describe, expect, it } from 'vitest'
+import db from '@/db'
+import { failedSyncs } from '@/db/schema/failedSyncs.schema'
+import { syncedPayments } from '@/db/schema/syncedPayments.schema'
+import { SyncEntityType, SyncEventType, SyncStatus, syncLogs } from '@/db/schema/syncLogs.schema'
+
+describe('POST /api/webhook — invoice.paid without a prior created log', () => {
+  const apis = setupWebhookTest()
+
+  it('pays successfully even when no invoice.created log exists', async () => {
+    await seedConnectedPortal()
+    await seedSyncedInvoice({ status: 'success' })
+    // No seedSyncLog(): the invoice.created log is absent, so the paid log must
+    // default its NOT-NULL entityType rather than inherit it. Without the
+    // default the log INSERT rolls back the transaction after markInvoicePaid
+    // already ran, leaving a failed_syncs row that re-pays on retry.
+
+    const res = await postWebhook(buildPaidInvoiceWebhook())
+    expect(res.status).toBe(200)
+
+    expect(apis.xero.markInvoicePaid).toHaveBeenCalledTimes(1)
+
+    // The payment record is committed, so a retry short-circuits (no double pay).
+    expect(await db.select().from(syncedPayments)).toHaveLength(1)
+
+    // The paid success log still writes, defaulting entityType to invoice.
+    const paidLogs = await db
+      .select()
+      .from(syncLogs)
+      .where(eq(syncLogs.eventType, SyncEventType.PAID))
+    expect(paidLogs).toHaveLength(1)
+    expect(paidLogs[0]).toMatchObject({
+      status: SyncStatus.SUCCESS,
+      entityType: SyncEntityType.INVOICE,
+    })
+
+    // The payment succeeded, so nothing is recorded for retry.
+    expect(await db.select().from(failedSyncs)).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
## What

Fixes a latent defect in `syncPaidInvoiceToXero` (invoice.paid flow) that can duplicate a payment in Xero. Follow-up to the merged PR #67; ref [OUT-3951](https://linear.app/assemblycom/issue/OUT-3951/integration-tests-for-invoicepaid-webhook).

## The bug

The success-path sync log was built by spreading `prevSyncLog` (from `getInvoiceCreatedSyncLog`) without hardcoding the `NOT NULL` `entityType` column:

```ts
await syncLogsService.createSyncLog({
  ...prevSyncLog,          // undefined when no invoice.created log exists
  eventType: SyncEventType.PAID,
  status: SyncStatus.SUCCESS,
  syncDate: new Date(),
})
```

When no prior `invoice.created` log exists, `prevSyncLog` is `undefined`, so `entityType` is missing and the INSERT fails **inside the transaction**. The rollback discards the `synced_invoices` status update and the `synced_payments` write — but `markInvoicePaid` already ran **outside** the transaction, so the payment is real in Xero. The `handleEvent` catch then records a `failed_syncs` retry row. On retry, `getPaymentForInvoiceId` finds no local record (rolled back), so `markInvoicePaid` runs again → **duplicate payment in Xero**.

The catch block already hardcodes `entityType`; the success path did not.

## The fix

One line: add `entityType: SyncEntityType.INVOICE` to the success-log payload, matching the catch block. It's a no-op when `prevSyncLog` is present (`getInvoiceCreatedSyncLog` always filters `entityType = INVOICE`).

## Test

`invoicePaid/noPriorCreatedLog.test.ts` — seeds a synced invoice with no prior created log, posts the paid webhook, and asserts 200, a committed `synced_payments` row, a `PAID` success log with `entityType`, and empty `failed_syncs`. Verified failing (500) before the fix.

## Verification

- `pnpm test run test/integration/webhook/invoicePaid/` → 7 files / 8 tests pass
- `pnpm typecheck` and `pnpm lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)